### PR TITLE
Add Address DB table usage to the Division

### DIFF
--- a/app/Casts/Division/Location.php
+++ b/app/Casts/Division/Location.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Casts\Division;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+class Location implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        if (!is_array($value)) {
+            $data = json_decode($value,true);
+        }
+
+        if (!empty($data) && ($data['latitude'] !== 0 || $data['longitude'] !== 0)) {
+            $data['latitude'] = $this->normalizeValue($data['latitude']);
+            $data['longitude'] = $this->normalizeValue($data['longitude']);
+
+            return $data;
+        }
+
+        return [];
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        $data = [];
+
+        if (is_array($value)) {
+            $data = [$key => $value];
+        } else {
+            $data = $value ? [$key => json_decode($value,true)] : [];
+
+            if (empty($data)) {
+                $data[$key]['latitude'] = 0;
+                $data[$key]['longitude'] = 0;
+
+            }
+        }
+
+        return json_encode($data[$key]);
+    }
+
+    /**
+     * Add trailing 'zero' symbol if coordinate value has one digit before the dot.
+     * Without it Longitude or Latitude values in it's input fields displays wrong value.
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    protected function normalizeValue(string $value): string
+    {
+        return rtrim(sprintf("%09.6f", $value), '0');
+    }
+}

--- a/app/Casts/Division/WorkingHours.php
+++ b/app/Casts/Division/WorkingHours.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Casts\Division;
+
+use App\Traits\WorkTimeUtilities;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class WorkingHours implements CastsAttributes
+{
+    use WorkTimeUtilities;
+
+    /**
+     * Cast the given value.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        $data = $value;
+
+        if (!empty($data)) {
+            $data = json_decode($value,true);
+        }
+
+        return $this->prepareWorkingHours($data, true);
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        $data = [];
+
+        if (is_array($value)) {
+            $data = [$key => $value];
+        } else {
+            $data = $value ? [$key => json_decode($value,true)] : [$key => []];
+        }
+
+        return json_encode($this->prepareWorkingHours($data[$key]));
+    }
+
+    /**
+     * Change divider between hours and minutes
+     *
+     * @param array $workingHours   // Array with work hours time data
+     * @param bool $dotToColon      // Determine how divider must be switched
+     *
+     * @return array
+     */
+    public function prepareWorkingHours(array $workingHours, bool $dotToColon = false): array
+    {
+        return $this->prepareTimeToRequest($workingHours, $dotToColon);
+    }
+}

--- a/app/Livewire/Division/DivisionForm.php
+++ b/app/Livewire/Division/DivisionForm.php
@@ -8,6 +8,7 @@ use App\Traits\AddressSearch;
 use App\Traits\WorkTimeUtilities;
 use App\Livewire\Division\Forms\DivisionFormRequest;
 
+
 // TODO: divide this class onto three ones: Divisions as parent class and Division Create & DivisionUpdate extends Division
 class DivisionForm extends Component
 {
@@ -65,9 +66,12 @@ class DivisionForm extends Component
 
     public function getDivision($id)
     {
-        $this->formService->setDivision(Division::find($id)->toArray());
-        $this->formService->setDivisionParam('phones', $this->formService->getDivisionParam('phones')[0]);
-        $this->formService->setDivisionParam('addresses', $this->formService->getDivisionParam('addresses')[0]);
+        $division = Division::find($id);
+
+        $this->formService->setDivision($division->toArray());
+
+        $this->formService->setDivisionParam('addresses', $division->address->toArray());
+
         $this->address = $this->formService->getDivisionParam('addresses');
 
         if ($this->formService->isDivisionParamExistAndNull('working_hours')) {

--- a/app/Models/Division.php
+++ b/app/Models/Division.php
@@ -2,8 +2,12 @@
 
 namespace App\Models;
 
+use App\Casts\Division\Location;
+use App\Casts\Division\WorkingHours;
+use App\Models\Relations\Address;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 
 class Division extends Model
 {
@@ -14,9 +18,8 @@ class Division extends Model
         'external_id',
         'name',
         'type',
-        'mountaint_group',
+        'mountain_group',
         'location',
-        'addresses',
         'phones',
         'email',
         'working_hours',
@@ -27,21 +30,17 @@ class Division extends Model
     ];
 
     protected $casts = [
-        'location' => 'array',
-        'addresses' => 'array',
+        'location' => Location::class,
         'healthcare_services' => 'array',
         'phones' => 'array',
-        'working_hours' => 'array',
+        'working_hours' => WorkingHours::class,
         'is_active' => 'boolean',
     ];
 
     public $attributes = [
         'is_active' => false,
-        'mountaint_group' => false,
-        'uuid' => 'string',
-        'addresses' => '[]',
-        'location' => '[]',
-        'working_hours' =>  '[]',
+        'mountain_group' => false,
+        'uuid' => 'string'
     ];
 
     public function legalEntity()
@@ -54,8 +53,8 @@ class Division extends Model
         return $this->hasMany(HealthcareService::class);
     }
 
-    public function setLocationAttribute($value)
+    public function address(): MorphOne
     {
-        $this->attributes['location'] = $value ?: json_encode([]);
+        return $this->morphOne(Address::class, 'addressable');
     }
 }

--- a/app/Models/Relations/Address.php
+++ b/app/Models/Relations/Address.php
@@ -7,6 +7,14 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class Address extends Model
 {
+    protected $hidden = [
+        'id',
+        'created_at',
+        'updated_at',
+        'addressable_id',
+        'addressable_type'
+    ];
+
     protected $fillable = [
         'type',
         'country',

--- a/app/Repositories/AddressRepository.php
+++ b/app/Repositories/AddressRepository.php
@@ -23,9 +23,10 @@ class AddressRepository
                     [
                         'addressable_type' => get_class($model),
                         'addressable_id' => $model->id
-                    ],
-                    $addressData
+                    ]
                 );
+
+                $address->fill($addressData);
 
                 $model->address()->save($address);
             }

--- a/app/Services/DivisionApiService.php
+++ b/app/Services/DivisionApiService.php
@@ -57,8 +57,8 @@ class DivisionApiService
             'name' => $data['name'],
             'type' =>$data['type'],
             'email' => $data['email'],
-            'phones' => [$data['phones']],
-            'addresses' => [$data['addresses']]
+            'phones' => [$data['phones']], // ESOZ expect to get an array of the objects
+            'addresses' => [$data['addresses']], // ESOZ expect to get an array of the addresses,
         ];
 
         if (!empty($data['external_id'])) {
@@ -75,7 +75,7 @@ class DivisionApiService
         }
 
         if (!empty($data['working_hours'])) {
-            $params['working_hours'] = $this->prepareWorkingHours($data['working_hours']);;
+            $params['working_hours'] = $this->prepareWorkingHours($data['working_hours']);
         }
         else {
             foreach($this->weekdays as $day => $name) {

--- a/database/migrations/2024_01_22_081531_create_divisions_table.php
+++ b/database/migrations/2024_01_22_081531_create_divisions_table.php
@@ -17,9 +17,8 @@ return new class extends Migration
                 $table->string('external_id')->nullable();
                 $table->string('name');
                 $table->string('type')->nullable();
-                $table->boolean('mountaint_group');
-                $table->jsonb('location');
-                $table->jsonb('addresses');
+                $table->boolean('mountain_group');
+                $table->jsonb('location')->nullable();
                 $table->jsonb('phones');
                 $table->string('email');
                 $table->jsonb('working_hours')->nullable();


### PR DESCRIPTION
This PR concerns to the #122 ISSUE:

Що було зроблено: 
- змінено роботу з компонентом AddressSearch так, щоб він зберігав дані в окрему таблицю (Address) з використанням відповідного репозиторію;
- скореговано збереження даних, отриманих після синхронізації у формат, відповідно до формату бази даних, а також в зворотному напрямку - при роботі з API;
- скореговано таблицю Division в частині назв атрибутів. Також прибрано атрибут (колонку) addresses.
(потребує виконання міграції, щоб зміни набрали чинності)