### PR TITLE
#i167 Fix impossibility to log in after creating the LegalEntity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ yarn-error.log
 /.vscode
 _ide_helper.php
 _ide_helper_models.php
+storage/debugbar

--- a/app/Livewire/LegalEntity/LegalEntity.php
+++ b/app/Livewire/LegalEntity/LegalEntity.php
@@ -774,7 +774,9 @@ class LegalEntity extends Component
 
         try{
             $user->save();
-        } catch (\Exception $e) {
+
+            $user->refresh();
+        } catch (Exception $e) {
             $this->dispatchErrorMessage(__('Сталася помилка під час обробки запиту'), ['error' => $e->getMessage()]);
 
             return null;


### PR DESCRIPTION
Виправлено помилку, після якої було неможливо залогінитись в новоствореному legalEntity.
Також додано до .gitignore дані з дебаг-консолі.