### PR TITLE
Fix error for label when browser do autocomplete on Label

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -97,6 +97,12 @@ input:-webkit-autofill:active {
     background-clip: text !important;
 }
 
+input.not-empty + label,
+input.not-empty ~ label {
+    @apply text-blue-600 dark:text-blue-500 scale-75 -translate-y-6;
+}
+
+
 .input-select {
     @apply input text-gray-500 dark:text-gray-400 dark:border-gray-700 dark:focus:border-blue-500 dark:bg-gray-800
 }

--- a/resources/views/components/forms/autofill-detector.blade.php
+++ b/resources/views/components/forms/autofill-detector.blade.php
@@ -1,0 +1,69 @@
+{{--
+    Blade component: <x-autofill-detector />
+    Purpose: Force Chrome to "reveal" autofill values (e.g. after Ctrl+R).
+
+    How it works:
+    1. After window.load, we delay 150ms to let Chrome finish autofill
+    2. Find the first visible input field (email, text, password, etc.)
+    3. Focus the input to trigger Chrome autofill rendering
+    4. After 50ms, check .value — if present, add .not-empty class and trigger 'input' event
+    5. Then blur the field to avoid leaving it focused
+--}}
+
+@once
+    @push('scripts')
+        <script>
+            window.addEventListener('load', () => {
+                /*
+                 * In more complex cases (slow connection, Alpine, Livewire, SSO, devtools throttling),
+                 * Chrome (and borwsers with Chrpmium engine) inserts autofill values only after load."
+                 * This timeout need to pass this delay to ensure autofill has been applied
+                 */
+                setTimeout(() => {
+                    /* List of prioritized selectors to scan for autofill */
+                    const selectors = [
+                        'input.input.peer', // Inputs styled with Tailwind peer classes
+                        'input[type=email]',
+                        'input[type=password]',
+                        'input[type=text]'
+                    ];
+
+                    let autofillInput = null;
+
+                    /* Find the first visible and enabled input field */
+                    for (const selector of selectors) {
+                        const candidates = Array.from(document.querySelectorAll(selector));
+
+                        autofillInput = candidates.find(el =>
+                            el.offsetParent !== null && // Here: check if the element visible and present in DOM
+                            !el.disabled &&
+                            !el.readOnly &&
+                            el.type !== 'hidden'
+                        );
+
+                        if (autofillInput) break;
+                    }
+
+                    if (!autofillInput) return;
+
+                    /* Chrome only makes autofill value visible after focus */
+                    autofillInput.focus();
+
+                    /* Wait 50ms to allow Chrome to populate .value */
+                    setTimeout(() => {
+                        if (autofillInput.value) {
+                            /* Add .not-empty class to trigger floating label */
+                            autofillInput.classList.add('not-empty');
+
+                            /* Dispatch input event so Alpine/Livewire can react */
+                            autofillInput.dispatchEvent(new Event('input', { bubbles: true }));
+                        }
+
+                        /* Remove focus so user doesn't see blinking cursor */
+                        autofillInput.blur();
+                    }, 50);
+                }, 150); // Initial delay after page load
+            });
+        </script>
+    @endpush
+@endonce

--- a/resources/views/components/forms/autofill-trap.blade.php
+++ b/resources/views/components/forms/autofill-trap.blade.php
@@ -1,0 +1,37 @@
+{{--
+    This component serves to prevent unwanted browser autofill (especially Chrome),
+    by confusing it with hidden decoy fields.
+
+    Use it at the beginning of your form.
+
+    The primary "username" decoy field is always added, as it proved to be critical.
+    You can add extra fields by passing an array to the `additionalTypes` prop,
+    e.g.: `additionalTypes="['password', 'email']"`.
+--}}
+
+@props([
+    /*
+     *Types of additional fields to include, besides the main "username" decoy field.
+     * By default, this is empty, as "username" is mandatory and most effective.
+     */
+    'additionalTypes' => [],
+    'usernameName' => 'username', // Keep fixed name "username"
+    'passwordName' => 'password_autofill_dummy_' . Str::random(8),
+    'emailName' => 'email_autofill_dummy_' . Str::random(8),
+])
+
+<div style="display:none;" aria-hidden="true" tabindex="-1">
+
+    {{-- The primary "username" decoy field, which proved effective --}}
+    <input type="text" name="{{ $usernameName }}" autocomplete="username" tabindex="-1">
+
+    @if(in_array('password', $additionalTypes))
+        {{-- Additional password field, if explicitly specified --}}
+        <input type="password" name="{{ $passwordName }}" autocomplete="new-password" tabindex="-1">
+    @endif
+
+    @if(in_array('email', $additionalTypes))
+        {{-- Additional email field, if explicitly specified --}}
+        <input type="email" name="{{ $emailName }}" autocomplete="off" tabindex="-1">
+    @endif
+</div>

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -23,7 +23,7 @@
                     autocomplete="off"
                     wire:model="email"
                     aria-describedby="{{ $hasEmailError ? 'hasEmailErrorHelp' : '' }}"
-                    class="input {{ $hasEmailError  ? 'input-error border-red-500 focus:border-red-500' : ''}} peer"
+                    class="input peer {{ $hasEmailError ? 'input-error border-red-500 focus:border-red-500' : '' }} {{ !empty($email) ? 'not-empty' : '' }}"
                 />
 
                 @if($hasEmailError)
@@ -116,3 +116,5 @@
         </form>
     </x-authentication-card>
 </div>
+
+<x-forms.autofill-detector />

--- a/resources/views/livewire/legal-entity/step/_step_edrpou.blade.php
+++ b/resources/views/livewire/legal-entity/step/_step_edrpou.blade.php
@@ -19,15 +19,22 @@
         <legend x-text="title" class="legend"></legend>
     </template>
 
+    <!-- Autofill Trap -->
+    <x-forms.autofill-trap />
+
+    <!-- Main Form part -->
     <div class='form-row-3'>
         <div class="form-group group" x-id="['edrpou']">
             <input
+            role="none"
                 required
                 type="text"
                 :id="$id('edrpou')"
                 maxlength="10"
                 placeholder=" "
                 value="{{ $edrpou ?? '' }}"
+                autocomplete="off"
+                name="edrpou_{{ uniqid() }}"
                 wire:model="legalEntityForm.edrpou"
                 aria-describedby="{{ $hasEdrpouError ? 'edrpouErrorHelp' : '' }}"
                 class="input {{ $hasEdrpouError ? 'input-error border-red-500 focus:border-red-500' : ''}} peer"
@@ -47,3 +54,5 @@
         </div>
     </div>
 </fieldset>
+
+<x-forms.autofill-detector />


### PR DESCRIPTION
This PR concerns #219 ISSUE

Спроба пофіксити проблему, коли при автозаповненні на HTML-елементі input мітка не підіймається вгору, а залишається на місці, утворюючи текстовий мікс.
Також було додано два blade-компоненти, які відповдають за автопідняття мітки при автозаповненні і недопуску заповлення полів, які не відносяться до збережених даних.