### PR TITLE
263 feat: Add Send Email Event to the LegalEntity's User creation

### DIFF
--- a/app/Events/LegalEntityCreate.php
+++ b/app/Events/LegalEntityCreate.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\User;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LegalEntityCreate
+{
+    use
+        Dispatchable,
+        SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public User $authenticatedUser,
+        public User $owner,
+        public string $password
+    ) {}
+}

--- a/app/Listeners/EmailVerification.php
+++ b/app/Listeners/EmailVerification.php
@@ -2,11 +2,11 @@
 
 namespace App\Listeners;
 
+use Log;
 use Exception;
-use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
-use Log;
+use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 
 class EmailVerification extends SendEmailVerificationNotification
 {

--- a/app/Listeners/SendUserCredentialsListener.php
+++ b/app/Listeners/SendUserCredentialsListener.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Listeners;
+
+use Throwable;
+use App\Events\LegalEntityCreate;
+use App\Mail\OwnerCredentialsMail;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+
+class SendUserCredentialsListener implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * Amount of the trying attempt when fail
+     *
+     * Important:
+     * - The `$tries` property must be declared as `public` to be recognized by Laravel's queue worker.
+     * - If these properties are `protected` or `private`, they will be ignored.
+     * - Laravel uses reflection or direct property access (e.g., `$this->tries`) and does not
+     *   call any getter methods for these values.
+     *
+     * Example:
+     * public int $tries = 3;
+     *
+     * Related Docs:
+     * @see https://laravel.com/docs/queues#retrying-failed-jobs
+     *
+     * @var int
+     */
+    public ?int $tries;
+
+    /**
+     * How many seconds should be passed before the next try
+     *
+     * Important:
+     * - The `$backoff` property must be declared as `public` to be recognized by Laravel's queue worker.
+     * - If these properties are `protected` or `private`, they will be ignored.
+     * - Laravel uses reflection or direct property access (e.g., `$this->tries`) and does not
+     *   call any getter methods for these values.
+     *
+     * Example:
+     * public int $tries = 3;
+     *
+     * Related Docs:
+     * @see https://laravel.com/docs/queues#retrying-failed-jobs
+     *
+     * @var int
+     */
+    public ?int $backoff;
+
+    public function __construct()
+    {
+        $this->tries = config('ehealth.emailers.failCredentialsTries');
+        $this->backoff = config('ehealth.emailers.credentialsQueueTimeout');
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(LegalEntityCreate $event): void
+    {
+        // Check: if user that create the LegalEntity is Owner-user just skip this listener
+        if (strtolower($event->authenticatedUser->email) === $event->owner->email) {
+            return;
+        }
+
+        // Send a link to the owner's email to verify the given address
+        if ($event->owner instanceof MustVerifyEmail && ! $event->owner->hasVerifiedEmail()) {
+            Log::info(static::class . ": send email verification LINK: to email: {$event->owner->email}");
+
+            $event->owner->sendEmailVerificationNotification();
+        }
+
+        Log::info(static::class . ' started for: ' . $event->owner->email);
+
+        // Send a credentials for the owner's account (only for local login!)
+        Mail::to($event->owner->email)
+            ->send(new OwnerCredentialsMail($event->owner->email, $event->password));
+    }
+
+    /**
+     * Log when failed
+     *
+     * @param LegalEntityCreate $event
+     * @param \Throwable $err
+     *
+     * @return void
+     */
+    public function failed(LegalEntityCreate $event, Throwable $err): void
+    {
+        Log::error(static::class . 'failed', [
+            'user_email' => $event->owner->email,
+            'error' => $err->getMessage()
+        ]);
+    }
+}

--- a/app/Livewire/Auth/Register.php
+++ b/app/Livewire/Auth/Register.php
@@ -24,7 +24,7 @@ class Register extends Component
     /**
      * Handle an incoming registration request.
      */
-    public function register()
+    public function register(): void
     {
         $userData = $this->validate([
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:' . User::class],
@@ -55,7 +55,7 @@ class Register extends Component
             session()->flash('error', __('Помилка при створенні користувача. Зверніться до адміністратора'));
 
             // Stay on the Register page even if an error(s) occur
-            return $this->redirect(request()->header('Referer'), navigate: true);
+            $this->redirect(request()->header('Referer'), navigate: true);
         }
     }
 

--- a/app/Livewire/LegalEntity/LegalEntity.php
+++ b/app/Livewire/LegalEntity/LegalEntity.php
@@ -16,10 +16,9 @@ use Livewire\WithFileUploads;
 use App\Traits\AddressSearch;
 use App\Livewire\Actions\Logout;
 use App\Models\Employee\Employee;
+use App\Events\LegalEntityCreate;
 use Illuminate\Support\Facades\DB;
-use App\Mail\OwnerCredentialsMail;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Auth;
 use App\Classes\Cipher\Traits\Cipher;
 use App\Classes\Cipher\Api\CipherApi;
@@ -741,32 +740,21 @@ abstract class LegalEntity extends Component
         $authenticatedUser = Auth::user();
 
         // Retrieve the email address of the legal entity owner from the form or set it to null
-        $email = $this->legalEntityForm->owner['email'] ?? null;
+        $ownerEmail = $this->legalEntityForm->owner['email'] ?? null;
 
         // Generate a random password
         $password = Str::random(10);
 
         // Check if a user with the provided email already exists
-        $user = User::where('email', $email)->first();
-
-        // If the authenticated user claim self as the owner of the Legal Entity, use them as the user
-        $isOwner = isset($authenticatedUser->email) && strtolower($authenticatedUser->email) === $email;
-
-        if ($isOwner) {
-            // If the authenticated user is the LegalEntity owner, use them as the user
-            $user = $authenticatedUser;
-        } elseif (!$user) {
-            // If no user exists with that email, create a new user (new owner)
-            $user = User::create([
-                'email'    => $email,
+        $owner = User::where('email', $ownerEmail)->first() ?? User::create([
+                'email'    => $ownerEmail,
                 'password' => Hash::make($password),
-            ]);
-        }
+            ]);;
 
         try{
-            $user->save();
+            $owner->save();
 
-            $user->refresh();
+            $owner->refresh();
         } catch (Exception $e) {
             $this->dispatchErrorMessage(__('Сталася помилка під час обробки запиту'), ['error' => $e->getMessage()]);
 
@@ -776,21 +764,18 @@ abstract class LegalEntity extends Component
         auth()->shouldUse('web');
 
         // Assign the 'OWNER' role to the user authenticated via web guad
-        $user->assignRole('OWNER');
+        $owner->assignRole('OWNER');
 
         auth()->shouldUse('ehealth');
 
         // Assign the 'OWNER' role to the user authenticaed via ehealth guard
-        $user->assignRole('OWNER');
+        $owner->assignRole('OWNER');
 
-        if (!$isOwner) {
-            event(new Registered($user));
+        // Send credentials and email verification link
+        event(new LegalEntityCreate($authenticatedUser, $owner, $password));
 
-            // Send an email with the owner credentials to the user
-            Mail::to($user->email)->send(new OwnerCredentialsMail($user->email, $password));
-            Mail::to($authenticatedUser->email)->send(new OwnerCredentialsMail( '', '', __('Нового користувача зареєстровано в системі. На вказану адресу ' . $user->email . ' надіслано дані для входу в систему')));
-        }
+        Log::info("LegalEntity: New OWNER has been successfully registered! User credentials was sended to the {$owner->email} address");
 
-        return $user;
+        return $owner;
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -6,8 +6,10 @@ use App\Events\ApplyUserTeamId;
 use App\Listeners\ApplyUserTeamIdListener;
 use App\Listeners\EmailVerification;
 use App\Listeners\LogLockout;
+use App\Events\LegalEntityCreate;
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Auth\Events\Registered;
+use App\Listeners\SendUserCredentialsListener;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
@@ -24,7 +26,7 @@ class EventServiceProvider extends ServiceProvider
         ],
         Lockout::class => [
             LogLockout::class
-        ]
+        ],
     ];
 
     /**
@@ -40,6 +42,6 @@ class EventServiceProvider extends ServiceProvider
      */
     public function shouldDiscoverEvents(): bool
     {
-        return false;
+        return true;
     }
 }

--- a/config/ehealth.php
+++ b/config/ehealth.php
@@ -935,4 +935,9 @@ return [
             'person_verification:write',
         ]
     ],
+
+    'emailers' => [
+        'credentialsQueueTimeout' => 60,
+        'failCredentialsTries' => 3
+    ]
 ];

--- a/resources/lang/uk/forms.php
+++ b/resources/lang/uk/forms.php
@@ -286,6 +286,7 @@ return [
     'del_and_choose_value' => 'Видаліть вміст і оберіть значення зі списку',
     'local_login' => 'Увага! Ви намагєтесь увійти в локальну частину МІС',
     'local_login_warning' => 'Робота з сервером ЕСОЗ буде неможлива!',
+    'legal_entity_registered' => 'Новий заклад успішно зареєстровано',
 
     // License-related Forms
     'license' => [


### PR DESCRIPTION
This PR concerns to the #263 ISSUE.

Змінено механізм надсилання листа з аутентифікаційними даними  і підвердження email для новоствореного Власника Закладу у випадку, коли Заклад створювався іншим користувачем. 
Змінено логіку створення користувача-власника, у випадку реєстрації Закладу іншим співробітником.