### PR TITLE
#264 feat: Change user logic for noTaxId behaviour

### DIFF
--- a/app/Livewire/LegalEntity/CreateLegalEntity.php
+++ b/app/Livewire/LegalEntity/CreateLegalEntity.php
@@ -330,6 +330,12 @@ class CreateLegalEntity extends LegalEntity
         // Check if the owner information is available in the cache
         $personData = $this->legalEntityForm->owner;
 
+        // If no_tax_id=true set related fields to empty
+        if ($personData['noTaxId']) {
+            $personData['taxId'] = '';
+            $this->legalEntityForm->owner['taxId'] = '';
+        }
+
         // Store the owner information in the cache
         if ($this->checkOwnerChanges()) {
             Cache::put($this->ownerCacheKey, $personData, now()->days(90));

--- a/app/Livewire/LegalEntity/Forms/LegalEntitiesForms.php
+++ b/app/Livewire/LegalEntity/Forms/LegalEntitiesForms.php
@@ -16,8 +16,8 @@ use App\Rules\InDictionary;
 use App\Rules\UniqueEdrpou;
 use App\Rules\DocumentNumber;
 use App\Rules\PhoneDublicates;
-use App\Exceptions\CustomValidationException;
 use Illuminate\Support\Facades\Log;
+use App\Exceptions\CustomValidationException;
 use Illuminate\Validation\ValidationException;
 
 class LegalEntitiesForms extends Form
@@ -68,7 +68,7 @@ class LegalEntitiesForms extends Form
             'owner.gender' => 'required|string',
             'owner.birthDate' => ['required', 'date', new BirthDate($this->owner['email'] ?? ''), new AgeCheck()],
             'owner.noTaxId' => 'boolean|nullable',
-            'owner.taxId' => ['required', new TaxId($this->owner['email'] ?? '', $this->owner['noTaxId'])],
+            'owner.taxId' => ['required_unless:owner.noTaxId,true', 'string', new TaxId($this->owner['email'] ?? '')],
             'owner.documents.type' => ['required','string', new InDictionary('DOCUMENT_TYPE')],
             'owner.documents.number' => ['required', 'string', new DocumentNumber($this->owner['documents']['type'] ?? '')],
             'owner.phones' => 'required|array',
@@ -113,7 +113,7 @@ class LegalEntitiesForms extends Form
             'owner.age_check' => 'Вік власника має бути не менше 18 років',
             'owner.gender' => __('Це поле є обов\'язковим до заповнення'),
             'owner.phones' => __('Контактний телефон є обов\'язковим до заповнення'),
-            'owner.taxId.required' => __('Номер ІПН чи РНОКПП є обов\'язковим до заповнення'),
+            'owner.taxId.required_unless' => __('Номер ІПН чи РНОКПП є обов\'язковим до заповнення'),
             'owner.documents.type.required' => __('Тип документа є обов\'язковим до заповнення'),
             'owner.position.required' => __('Посада є обов\'язковою до заповнення'),
             'owner.email.unique' => 'Поле :attribute вже зареєстровано в системі',
@@ -206,7 +206,11 @@ class LegalEntitiesForms extends Form
 
         $userTaxId = $user?->party?->taxId;
 
-        if ($user && !empty($userTaxId) && $userTaxId !== $this->owner['taxId']) {
+        if ($user &&
+            filled($userTaxId) &&
+            isset($this->owner['taxId']) &&
+            $userTaxId !== $this->owner['taxId']
+        ) {
             Log::error("rulesForOwner: user with specified email exists and has different tax ID");
 
             throw ValidationException::withMessages([

--- a/app/Livewire/LegalEntity/LegalEntity.php
+++ b/app/Livewire/LegalEntity/LegalEntity.php
@@ -439,6 +439,11 @@ abstract class LegalEntity extends Component
 
         $data = $this->convertArrayKeysToSnakeCase($data);
 
+        // If no_tax_id=true its means that taxID should store related document's number
+        if ($data['owner']['no_tax_id']) {
+            $data['owner']['tax_id'] = $data['owner']['documents']['number'];
+        }
+
         // Converting documents to array
         if (isset($data['owner']['documents'])) {
             $data['owner']['documents'] = [$data['owner']['documents']];

--- a/app/Rules/TaxId.php
+++ b/app/Rules/TaxId.php
@@ -42,7 +42,7 @@ class TaxId implements ValidationRule
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if ($this->noTaxId) {
-            if (!preg_match('/^([0-9]{9}|[А-ЯЁЇIЄҐ]{2}\\d{6})$/u', $value)) {
+            if (!preg_match('/^([0-9]{10}|[А-ЯЁЇIЄҐ]{2}\\d{6})$/u', $value)) {
                 $fail(__('validation.attributes.errors.invalidNationalId'));
             }
         } else {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -110,7 +110,7 @@ input:-webkit-autofill:active {
 }
 
 .label {
-    @apply peer-focus:font-medium absolute text-sm text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-6 scale-75 top-3 z-10 origin-[0] peer-focus:start-0 rtl:peer-focus:translate-x-1/4 rtl:peer-focus:left-auto peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-6
+    @apply peer-focus:font-medium absolute text-sm text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-6 scale-75 top-3 z-10 origin-[0] peer-focus:start-0 rtl:peer-focus:translate-x-1/4 rtl:peer-focus:left-auto peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-6 peer-disabled:text-gray-300
 }
 
 /* Fixes the bug with autofill and floating label, see Vitaliy-1/openHealth#219 */

--- a/resources/views/livewire/legal-entity/step/_step_owner.blade.php
+++ b/resources/views/livewire/legal-entity/step/_step_owner.blade.php
@@ -327,7 +327,23 @@
     {{-- Owner IPN --}}
     <div
         class='form-row-3'
-        x-data="{ showNoTaxId: $wire.entangle('legalEntityForm.owner.noTaxId') }"
+        x-data="{
+            showNoTaxId: $wire.entangle('legalEntityForm.owner.noTaxId'),
+            taxId: $wire.entangle('legalEntityForm.owner.taxId'),
+            initialShowNoTaxId: null,
+
+            updateTaxIdInput() {
+                if (this.showNoTaxId) {
+                    this.$refs.taxIdInput.value = '';
+                } else {
+                    this.$refs.taxIdInput.value = this.showNoTaxId && this.initialShowNoTaxId ? '' : this.taxId;
+                }
+            }
+        }"
+        x-init="
+            initialShowNoTaxId = showNoTaxId;
+            updateTaxIdInput();
+        "
     >
         <div class="form-group group relative z-0">
             <input
@@ -337,9 +353,13 @@
                 name="taxId"
                 maxlength="10"
                 placeholder=" "
-                wire:model="legalEntityForm.owner.taxId"
+                x-model="taxId"
                 aria-describedby="{{ $hasOwnerTaxId ? 'ownerTaxIdErrorHelp' : '' }}"
                 class="input {{ $hasOwnerTaxId ? 'input-error border-red-500 focus:border-red-500' : ''}} peer"
+                :class="{ 'border-gray-200 dark:border-gray-700': showNoTaxId }"
+                :disabled="showNoTaxId"
+                x-ref="taxIdInput"
+                x-effect="updateTaxIdInput()"
             />
 
             @if($hasOwnerTaxId)
@@ -351,7 +371,8 @@
             <label
                 for="taxId"
                 class="label z-10"
-                x-text="showNoTaxId ? '{{ __('forms.document_no_tax_id') }}' : '{{ __('forms.number') . ' ' . __('forms.ipn') . ' / ' . __('forms.rnokpp') }}'"
+                :class="{ 'text-gray-200 dark:text-gray-700': showNoTaxId }"
+                x-text="'{{ __('forms.number') . ' ' . __('forms.ipn') . ' / ' . __('forms.rnokpp') }}'"
             ></label>
         </div>
 
@@ -361,7 +382,6 @@
                     type="checkbox"
                     id="noTaxId"
                     class="default-checkbox text-blue-500 focus:ring-blue-300"
-                    {{-- wire:model="legalEntityForm.owner.noTaxId" --}}
                     x-model="showNoTaxId"
                     :checked="showNoTaxId"
                 >


### PR DESCRIPTION
This PR concerned to the #264 ISSUE.

Що було зроблено:

При створенні LegalEntity, у випадку, коли користувач не має (в силу законних причин) призначеного йому ІПН, замість нього має використовуватись номер документа (паспорт або ID-картка).

Тому, в звичайному випадку, коли чекбокс "Відсутній ІПН / РНОКПП" не встановлено - користувач вводить свій ІПН, як звичайно.

Коли ж чекбокс "Відсутній ІПН / РНОКПП" встановлено - поле вводу для ІПН блокується і в якості номеру використовується номер того документу, який користувач вкаже в формі при реєстрації Закладу.