### PR TITLE
#290: Divide createOrUpdateLegalEntity() method to some different methods

### DIFF
--- a/app/Livewire/LegalEntity/CreateLegalEntity.php
+++ b/app/Livewire/LegalEntity/CreateLegalEntity.php
@@ -6,10 +6,14 @@ use Exception;
 use App\Models\License;
 use Illuminate\Support\Arr;
 use App\Models\Relations\Phone;
+use App\Livewire\Actions\Logout;
 use App\Models\Relations\Address;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Cache;
 use App\Repositories\PhoneRepository;
 use App\Repositories\AddressRepository;
+use Illuminate\Support\Facades\Redirect;
 use Illuminate\Validation\ValidationException;
 use App\Models\LegalEntity as LegalEntityModel;
 
@@ -467,6 +471,60 @@ class CreateLegalEntity extends LegalEntity
         return true;
     }
 
+      /**
+     * Handle success response from API request.
+     *
+     * @param array $response The response from the API request
+     * @return void
+     */
+    protected function handleSuccessResponse(array $response, array $requestData = [])
+    {
+        try {
+            DB::transaction(function() use($response, $requestData) {
+
+                $this->createNewLegalEntity($response);
+
+                setPermissionsTeamId($this->legalEntity->id);
+
+                $this->createLicense($response['data']['license']);
+
+                try {
+                    $user = $this->createUser();
+                } catch (Exception $err) {
+                    throw new Exception('Error: create User: ' . $err->getMessage(), 2);
+                }
+
+                $user->unsetRelation('roles');
+
+                try {
+                    $this->createEmployeeRequest($this->legalEntity, $requestData, $response['urgent']['employee_request_id'], $user?->id ?? null);
+                } catch (Exception $err) {
+                    throw new Exception('Error: createEmployeeRequest: ' . $err->getMessage(), $err->getCode());
+                }
+
+                if (Cache::has($this->entityCacheKey)) {
+                    Cache::forget($this->entityCacheKey);
+                }
+
+                if (Cache::has($this->ownerCacheKey)) {
+                    Cache::forget($this->ownerCacheKey);
+                }
+
+                if (Cache::has($this->stepCacheKey)) {
+                    Cache::forget($this->stepCacheKey);
+                }
+            });
+
+            app(Logout::class)();
+
+            return Redirect::route('login') ?? null;
+        } catch (Exception $err) {
+            Log::error(__('Сталася помилка під час обробки запиту'), ['error' => $err->getMessage()]);
+
+            throw new Exception(__('Сталася помилка під час обробки запиту.' . ' Код помилки: ' . $err->getCode()));
+        }
+    }
+
     public function createLegalEntity()
     {
         $this->stepSignificancy();
@@ -475,9 +533,13 @@ class CreateLegalEntity extends LegalEntity
         if ($this->validationRequest()) {
             $result = $this->signLegalEntity();
 
-            // Handle successful API response
+            $requestData = $result['request'];
+
+            $response = $this->filterUnprovidedFields($result['response'], $requestData);
+
             try {
-                $this->handleSuccessResponse($result['response'], $result['request']);
+                // Handle successful API response
+                $this->handleSuccessResponse($response, $requestData);
             } catch(Exception $err) {
                 // Dispatch error message for possible errors
                 $this->dispatchErrorMessage($err->getMessage());

--- a/app/Livewire/LegalEntity/EditLegalEntity.php
+++ b/app/Livewire/LegalEntity/EditLegalEntity.php
@@ -145,26 +145,8 @@ class EditLegalEntity extends LegalEntity
 
         $result = $this->signLegalEntity();
 
-        $response = $result['response'];
         $data = $result['request'];
-        
-        /**
-         * This need to check beacuse it's not always present.
-         * Only way to determine if it's present is to check if it's not empty.
-         * This mainly concerns the editing of the legal entity.
-         */
-        if(!isset($data['accreditation'])) {
-            unset($response['data']['accreditation']);
-        }
-
-        /**
-         * This need to check beacuse it's not always present.
-         * Only way to determine if it's present is to check if it's not empty.
-         * This mainly concerns the editing of the legal entity.
-         */
-        if(!isset($data['archive'])) {
-            unset($response['data']['archive']);
-        }
+        $response = $this->filterUnprovidedFields($result['response'], $data);
 
         try {
             /**
@@ -179,7 +161,7 @@ class EditLegalEntity extends LegalEntity
             $legalEntity->refresh();
 
             DB::transaction(function() use($response, $data) {
-                $this->createOrUpdateLegalEntity($response);
+                $this->modifyLegalEntity($response);
 
                 $user = Auth::user();
 

--- a/app/Livewire/LegalEntity/LegalEntity.php
+++ b/app/Livewire/LegalEntity/LegalEntity.php
@@ -531,16 +531,10 @@ abstract class LegalEntity extends Component
         ]);
     }
 
-    /**
-     * Handle success response from API request.
-     *
-     * @param array $response The response from the API request
-     * @return void
-     */
-    protected function handleSuccessResponse(array $response, array $requestData = [])
+    protected function filterUnprovidedFields(array $response, array $requestData): array
     {
         /**
-         * This need to check beacuse it's not always present.
+         * This need to check because it's not always present.
          * Only way to determine if it's present is to check if it's not empty.
          * This mainly concerns the editing of the legal entity.
          */
@@ -549,7 +543,7 @@ abstract class LegalEntity extends Component
         }
 
         /**
-         * This need to check beacuse it's not always present.
+         * This need to check because it's not always present.
          * Only way to determine if it's present is to check if it's not empty.
          * This mainly concerns the editing of the legal entity.
          */
@@ -557,50 +551,7 @@ abstract class LegalEntity extends Component
             unset($response['data']['archive']);
         }
 
-        try {
-            DB::transaction(function() use($response, $requestData) {
-
-                $this->createOrUpdateLegalEntity($response);
-
-                setPermissionsTeamId($this->legalEntity->id);
-
-                $this->createLicense($response['data']['license']);
-
-                try {
-                    $user = $this->createUser();
-                } catch (Exception $err) {
-                    throw new Exception('Error: create User: ' . $err->getMessage(), 2);
-                }
-
-                $user->unsetRelation('roles');
-
-                try {
-                    $this->createEmployeeRequest($this->legalEntity, $requestData, $response['urgent']['employee_request_id'], $user?->id ?? null);
-                } catch (Exception $err) {
-                    throw new Exception('Error: createEmployeeRequest: ' . $err->getMessage(), $err->getCode());
-                }
-
-                if (Cache::has($this->entityCacheKey)) {
-                    Cache::forget($this->entityCacheKey);
-                }
-
-                if (Cache::has($this->ownerCacheKey)) {
-                    Cache::forget($this->ownerCacheKey);
-                }
-
-                if (Cache::has($this->stepCacheKey)) {
-                    Cache::forget($this->stepCacheKey);
-                }
-            });
-
-            app(Logout::class)();
-
-            return Redirect::route('login') ?? null;
-        } catch (Exception $err) {
-            Log::error(__('Сталася помилка під час обробки запиту'), ['error' => $err->getMessage()]);
-
-            throw new Exception(__('Сталася помилка під час обробки запиту.' . ' Код помилки: ' . $err->getCode()));
-        }
+        return $response;
     }
 
     /**
@@ -685,7 +636,7 @@ abstract class LegalEntity extends Component
      *
      * @return void
      */
-    protected function createOrUpdateLegalEntity(array $data): LegalEntityModel|null
+    protected function persistLegalEntity(array $data): array
     {
         // Get the UUID from the data, if it exists
         $uuid = $data['data']['id'] ?? '';
@@ -697,7 +648,7 @@ abstract class LegalEntity extends Component
 
         $phones = $data['data']['phones'];
         unset($data['data']['phones']);
-        unset($data['data']['license']); // UNset this because it already set if create or present and dany to modify if edit
+        unset($data['data']['license']); // Do unset this because it already set if create or present and deny to modify if edit
 
         try {
             // Find or create a new LegalEntity object by UUID
@@ -723,9 +674,38 @@ abstract class LegalEntity extends Component
             // Save or update the object in the database
             $this->legalEntity->save();
 
-            $this->addressRepository->addAddresses($this->legalEntity, $addressData);
+        } catch (Exception $err) {
+            throw new Exception('LegalEntity Create Error: ' . $err->getMessage());
+        }
 
-            $this->phoneRepository->syncPhones($this->legalEntity, $phones);
+        return ['addressData' => $addressData, 'phones' => $phones];
+    }
+
+    protected function createNewLegalEntity(array $data): LegalEntityModel|null
+    {
+        $legalEntityData = $this->persistLegalEntity($data);
+
+        try {
+            $this->addressRepository->addAddresses($this->legalEntity, $legalEntityData['addressData']);
+
+            $this->phoneRepository->addPhones($this->legalEntity, $legalEntityData['phones']);
+
+            $this->legalEntity->refresh();
+        } catch (Exception $err) {
+            throw new Exception('LegalEntity Create Error: ' . $err->getMessage());
+        }
+
+        return $this->legalEntity;
+    }
+
+    protected function modifyLegalEntity(array $data): LegalEntityModel|null
+    {
+        $legalEntityData = $this->persistLegalEntity($data);
+
+        try {
+            $this->addressRepository->syncAddresses($this->legalEntity, $legalEntityData['addressData']);
+
+            $this->phoneRepository->syncPhones($this->legalEntity, $legalEntityData['phones']);
 
             $this->legalEntity->refresh();
         } catch (Exception $err) {

--- a/app/Repositories/AddressRepository.php
+++ b/app/Repositories/AddressRepository.php
@@ -31,4 +31,38 @@ class AddressRepository
             }
         }
     }
+
+    /**
+     * Sync Addresses data to currant ($addresses) state.
+     * If $addresses is empty the existent data just will delete.
+     *
+     * @param  object  $model
+     * @param  array  $phones
+     *
+     * @return void
+     */
+    public function syncAddresses(object $model, array $addresses): void
+    {
+        //Remove all phones records belongs to the $model
+        Address::where([
+                    'addressable_type' => get_class($model),
+                    'addressable_id' => $model->id
+                ])
+                ->delete();
+
+        if (empty($addresses)) {
+            return;
+        }
+
+        foreach ($addresses as $addressData) {
+            $address = Address::updateOrCreate([
+                'addressable_type' => get_class($model),
+                'addressable_id' => $model->id
+            ],
+                $addressData
+            );
+
+            $model->address()->save($address);
+        }
+    }
 }


### PR DESCRIPTION
This PR concerns to the #290 ISSUE.

Що було зроблено:

- Метод createOrUpdateLEgalEntity() було розбити на три методи: persistLegalEntity(), сreateNewLegalEntity() і modifyLegalEntity();
- Додано новий метод filterUnprovidedFields() який фільтрує стан і дані змінних, які відповідають за акредитацію та архівацію (ці дані можуть бути відсутні);
- додано новий метод syncAddresses() в AddressRepository.