### PR TITLE
#248: First Login Synchronization (Division & Healthcare)

### DIFF
--- a/app/Classes/eHealth/Api/Division.php
+++ b/app/Classes/eHealth/Api/Division.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace App\Classes\eHealth\Api;
 
 use Exception;
+use App\Models\LegalEntity;
 use App\Traits\WorkTimeUtilities;
+use  Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use GuzzleHttp\Promise\PromiseInterface;
 use App\Classes\eHealth\EHealthResponse;
+use App\Models\Division as DivisionModel;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Http\Client\ConnectionException;
 use App\Classes\eHealth\EHealthRequest as Request;
-use App\Models\Division as DivisionModel;
-use  Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Log;
 
 class Division extends Request
 {
@@ -213,14 +214,14 @@ class Division extends Request
      *
      * @return array Normalized array ready for database upsert operation
      */
-    public static function normalizeResponseDataForUpsert(array $divisionsList): array
+    public static function normalizeResponseDataForUpsert(array $divisionsList, LegalEntity $legalEntity): array
     {
         foreach ($divisionsList as $index => $division) {
             unset($divisionsList[$index]['legal_entity_uuid']);
             unset($divisionsList[$index]['addresses']);
             unset($divisionsList[$index]['phones']);
 
-            $divisionsList[$index]['legal_entity_id'] = legalEntity()->id;
+            $divisionsList[$index]['legal_entity_id'] = $legalEntity->id;
 
             $divisionsList[$index]['location'] = empty($division['location'])
                 ? null

--- a/app/Classes/eHealth/Api/HealthcareService.php
+++ b/app/Classes/eHealth/Api/HealthcareService.php
@@ -3,6 +3,8 @@
 namespace App\Classes\eHealth\Api;
 
 use Exception;
+use App\Models\Division;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
 use App\Classes\eHealth\EHealthResponse;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -33,12 +35,15 @@ class HealthcareService extends Request
      *
      * @return PromiseInterface|EHealthResponse
      */
-    public function getMany(string $divisionUuid, string $url = self::URL, $query = null): PromiseInterface|EHealthResponse
+    public function getMany(?string $divisionUuid = null, string $url = self::URL, $query = null): PromiseInterface|EHealthResponse
     {
         $this->setValidator($this->validateHealthcareServicesList(...));
 
         $this->setDefaultPageSize();
-        $this->setDivisionUuidToQuery($divisionUuid);
+
+        if ($divisionUuid) {
+            $this->setDivisionUuidToQuery($divisionUuid);
+        }
 
         $mergedQuery = array_merge(
     $this->options['query'] ?? [],
@@ -111,6 +116,59 @@ class HealthcareService extends Request
     public function deactivate(string $uuid): PromiseInterface|EHealthResponse
     {
         return parent::patch(self::URL . '/' . $uuid . self::ACTIONS_DEACTIVATE);
+    }
+
+    /**
+     * Normalize healthcare services response data for database upsert operation.
+     *
+     * This method processes raw API response data by:
+     * - Converting division UUIDs to database IDs using batch lookup
+     * - Filtering out records with invalid division references
+     * - Converting array fields to JSON strings for JSONB database columns
+     *
+     * @param array $healthcareServicesList Raw healthcare services data from API
+     *
+     * @return array Processed data ready for database upsert operation
+     */
+    public static function normalizeResponseDataForUpsert(array $healthcareServicesList): array
+    {
+            // Get all unique division UUIDs for batch lookup
+            $divisionUuids = array_unique(array_column($healthcareServicesList, 'division_id'));
+
+            // Batch lookup: get division IDs mapped by their UUIDs to avoid redundant queries
+            $divisions = Division::whereIn('uuid', $divisionUuids)->pluck('id', 'uuid')->toArray();
+            Log::debug('Division UUID to ID mapping:', ['divisions' => $divisions, 'requested_uuids' => $divisionUuids]);
+
+            // First filter only records with valid division references
+            $filteredData = array_filter($healthcareServicesList, function ($item) use ($divisions) {
+                if (!isset($item['division_id'])) {
+                    return false;
+                }
+
+                if (!isset($divisions[$item['division_id']])) {
+                    return false;
+                }
+
+                return true;
+            });
+
+            // Now process only valid records
+            return array_map(function ($item) use ($divisions) {
+                // Convert division_id from UUID to ID
+                $item['division_id'] = $divisions[$item['division_id']];
+
+                // Convert JSON fields
+                $jsonFields = ['category', 'type', 'coverage_area', 'available_time', 'not_available', 'licensed_healthcare_service'];
+
+                foreach ($jsonFields as $field) {
+                    $value = Arr::get($item, $field);
+                    if (is_array($value)) {
+                        $item[$field] = json_encode($value);
+                    }
+                }
+
+                return $item;
+            }, $filteredData);
     }
 
     /**

--- a/app/Core/EHealthBatch.php
+++ b/app/Core/EHealthBatch.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+use Illuminate\Bus\Batch;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Bus;
+
+/**
+ * Helper class for creating batches with legal_entity_id tracking
+ */
+class EHealthBatch
+{
+    /**
+     * Create a new batch with legal_entity_id tracking
+     *
+     * @param array $jobs
+     * @param string $name
+     * @param int|string $legalEntityId
+     * @param string $queue
+     *
+     * @return Batch
+     */
+    public static function createWithLegalEntity(
+        array $jobs,
+        string $name,
+        int $legalEntityId,
+        string $queue = 'sync'
+    ): Batch {
+        // Create standard batch
+        $batch = Bus::batch($jobs)
+            ->name($name)
+            ->onQueue($queue)
+            ->dispatch();
+
+        // Update job_batches with legal_entity_id
+        DB::table('job_batches')
+            ->where('id', $batch->id)
+            ->update(['legal_entity_id' => $legalEntityId]);
+
+        return $batch;
+    }
+
+    /**
+     * Find batches by legal entity ID
+     *
+     * @param int $legalEntityId
+     *
+     * @return Collection
+     */
+    public static function findByLegalEntity(int $legalEntityId): Collection
+    {
+        return DB::table('job_batches')
+            ->where('legal_entity_id', $legalEntityId)
+            ->get();
+    }
+
+    /**
+     * Find failed batches by legal entity ID
+     *
+     * @param int $legalEntityId
+     *
+     * @return Collection
+     */
+    public static function findFailedByLegalEntity(int $legalEntityId, string $orderBy = 'desc'): Collection
+    {
+        return DB::table('job_batches')
+            ->where('legal_entity_id', $legalEntityId)
+            ->where('failed_jobs', '>', 0)
+            ->orderBy('cancelled_at', $orderBy)
+            ->get();
+    }
+}

--- a/app/Core/EHealthJob.php
+++ b/app/Core/EHealthJob.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+use Throwable;
+use Exception;
+use App\Models\User;
+use App\Core\EHealthBatch;
+use App\Models\LegalEntity;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Queue\InteractsWithQueue;
+use App\Classes\eHealth\EHealthResponse;
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use App\Exceptions\EHealth\EHealthResponseException;
+use App\Http\Middleware\Jobs\EnsureUserHasActiveSession;
+
+abstract class EHealthJob implements ShouldQueue
+{
+    use Queueable,
+        Batchable,
+        InteractsWithQueue;
+
+    public const string BATCH_NAME = 'syncJobs';
+
+    /** @var int Rate limit delay in seconds (50 requests per minute = 1 request every 1.2s, using 2s for safety) */
+    protected const int RATE_LIMIT_DELAY = 2;
+
+    // protected const array ERR_WITH_RETRY = [500, 502, 503, 408];
+
+    protected const array ERR_IMMEDIATE_FAIL = [400, 401, 403, 404, 429];
+
+    /**
+     * Get the batch name for job
+     *
+     * @return string
+     */
+    public function getBatchName(): string
+    {
+        return static::BATCH_NAME;
+    }
+
+    /**
+     * Authentication token for EHealth API requests
+     *
+     * @var string
+     */
+    protected string $token = '';
+
+    /**
+     * User associated with the job for session and policy checks
+     *
+     * @var User|null
+     */
+    public ?User $user;
+
+    /**
+     * Amount of times to attempt the job if it fails.
+     *
+     * @var int
+     */
+    public int $tries = 3;
+
+    /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int
+     */
+    public int $timeout = 60;
+
+    /**
+     * Amount of time (in seconds) to wait before retrying the job if it fails.
+     *
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [3, 10, 30];
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array
+     */
+    public function middleware(): array
+    {
+        return array_merge([
+            new EnsureUserHasActiveSession(maxAttempts: $this->tries, retryDelay: 3),
+        ], $this->getAdditionalMiddleware());
+    }
+
+    public function __construct(
+        public LegalEntity $legalEntity,
+        protected int $page = 1,
+        protected bool $isFirstLogin = false,
+        protected ?EHealthJob $nextEntity = null
+    ) {
+        $this->onQueue('sync');
+
+        // User will be set by middleware
+        $this->user = null;
+    }
+
+    public function handle(): void
+    {
+        echo "Processing Job: " . static::BATCH_NAME . " Page: " . $this->page . PHP_EOL;
+
+        $token = $this->getToken();
+
+        if (empty($token)) {
+            $this->fail( static::BATCH_NAME . " Page: " . $this->page . " - Missing Token");
+
+            return;
+        }
+
+        try {
+            $response = $this->sendRequest($token);
+        } catch (EHealthResponseException $err) {
+            $errCode = $err->getCode();
+            echo 'Job Exception (failing job): ' . $err->getMessage() . PHP_EOL;
+
+            if (in_array($errCode, static::ERR_IMMEDIATE_FAIL)) {
+                $this->fail($err);
+
+                return;
+            }
+
+            echo 'Job will be retried according to backoff settings' . PHP_EOL;
+
+            throw $err; // This will trigger Laravel's retry mechanism
+        } catch (Exception $err) {
+            // This is an unexpected exception, fail the job
+            echo 'Job Exception (failing job): ' . $err->getMessage() . PHP_EOL;
+
+            $this->fail($err);
+
+            return;
+        }
+
+        try {
+            $this->processResponse($response);
+        } catch (Exception $err) {
+            echo 'Job Exception (failing job): ' . $err->getMessage() . PHP_EOL;
+            // Let the job fail and be cancelled in case of exception
+            $this->fail($err);
+
+            return;
+        }
+
+        if ($response->isNotLast()) {
+            $this->batch()
+                ?->add(new static($this->legalEntity, page: $this->page + 1, isFirstLogin: $this->isFirstLogin, nextEntity: $this->nextEntity)
+                ->delay(now()->addSeconds(self::RATE_LIMIT_DELAY)));
+
+            return;
+        }
+
+        echo "Job COMPLETED: " . static::BATCH_NAME . PHP_EOL;
+
+        $nextJob = $this->getNextEntityJob();
+
+        if ($nextJob !== null) {
+            // $nextJob->delay(now()->addSeconds(self::RATE_LIMIT_DELAY));
+            echo "Scheduling next job: " . $nextJob::BATCH_NAME . PHP_EOL;
+
+            EHealthBatch::createWithLegalEntity([$nextJob], $nextJob::BATCH_NAME, $this->legalEntity->id, 'sync');
+        }
+    }
+
+    // Handle job failure
+    public function failed(?Throwable $exception): void
+    {
+        Log::channel('e_health_errors')->error('Sync job failed: ', [
+            'EXCEPTION' => $exception::class,
+            'message' => $exception->getMessage(),
+            'attempts' => $this->attempts(),
+            'bastch_id' => $this->batch()?->id,
+            'batch_name' => static::BATCH_NAME
+        ]);
+
+        echo "Job FAILED: " . static::BATCH_NAME . " Page: " . $this->page . PHP_EOL;
+
+        $this->batch()->cancel();
+    }
+
+    /**
+     * Get authentication token with deferred initialization
+     *
+     * @return string
+     */
+    protected function getToken(): string
+    {
+        if (empty($this->token)) {
+            $this->token = $this->getCurrentToken();
+        }
+
+        return $this->token;
+    }
+
+    protected function getCurrentToken(): string
+    {
+        if (!$this->user) {
+            return '';
+        }
+
+        $session = \DB::table('sessions')->where('user_id', $this->user->id)->first();
+
+        if (!$session) {
+            return '';
+        }
+
+        $payload = unserialize(base64_decode($session->payload));
+        $token = $payload['auth_token'] ?? '';
+
+        // TODO: Remove echoing & logging of token in production
+        \Log::info('Session token : ', ['token' => $token]);
+        echo "Session token: " . $token. '...' . PHP_EOL;
+
+        return $token;
+    }
+
+    // Get next entity job if needed
+    protected function getNextEntityJob(): ?EHealthJob
+    {
+        return $this->nextEntity;
+    }
+
+    // Get data from EHealth API
+    abstract protected function sendRequest(string $token): PromiseInterface|EHealthResponse;
+
+    // Store or update data in the database
+    abstract protected function processResponse(EHealthResponse $response): void;
+
+    /**
+     * Get additional middleware specific to the job implementation.
+     *
+     * This method must be implemented by child classes to define job-specific middleware
+     * that will be executed AFTER the base EnsureUserHasActiveSession middleware.
+     *
+     * Common middleware examples:
+     * - RateLimited('rate-limiter-name') for API rate limiting
+     * - Custom validation middleware
+     * - Logging middleware
+     *
+     * @return array Array of middleware instances
+     *
+     * @example
+     * protected function getAdditionalMiddleware(): array
+     * {
+     *     return [
+     *         new RateLimited('ehealth-api-calls'),
+     *         new CustomLoggingMiddleware(),
+     *     ];
+     * }
+     */
+    abstract protected function getAdditionalMiddleware(): array;
+}

--- a/app/Enums/JobStatus.php
+++ b/app/Enums/JobStatus.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum JobStatus: string
+{
+    case PENDING = 'PENDING';
+    case SUSPENDED = 'SUSPENDED';
+    case PROCESSING = 'PROCESSING';
+    case PAUSED = 'PAUSED';
+    case COMPLETED = 'COMPLETED';
+    case FAILED = 'FAILED';
+
+    public function label(): string
+    {
+        return match($this) {
+            self::PENDING => 'Очікується',
+            self::SUSPENDED => 'Призупинено',
+            self::PROCESSING => 'Обробляється',
+            self::PAUSED => 'На паузі',
+            self::COMPLETED => 'Виконано',
+            self::FAILED => 'Помилка'
+        };
+    }
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Events/EhealthUserLoggedIn.php
+++ b/app/Events/EhealthUserLoggedIn.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\LegalEntity;
+use App\Models\User;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class EhealthUserLoggedIn
+{
+    use Dispatchable, SerializesModels;
+
+    public string $token = '';
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public LegalEntity $legalEntity,
+        public bool $isFirstLogin = false
+    ) {
+    }
+}

--- a/app/Http/Controllers/Auth/EHealthLoginController.php
+++ b/app/Http/Controllers/Auth/EHealthLoginController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\Auth;
 use App\Auth\EHealth\Services\TokenStorage;
 use App\Classes\eHealth\Api\Employee;
 use App\Classes\eHealth\Exceptions\ApiException;
+use App\Events\EhealthUserLoggedIn;
 use App\Events\EHealthUserLogin;
 use App\Http\Controllers\Controller;
 use App\Mail\UserCredentialsMail;
@@ -21,7 +22,7 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Http\RedirectResponse;
 use App\Classes\eHealth\Api\EmployeeApi;
-use App\Models\Employee\EmployeeRequest;
+
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Validator;
 use App\Classes\eHealth\Request as EHealthRequest;
@@ -125,6 +126,9 @@ class EHealthLoginController extends Controller
         EHealthUserLogin::dispatch($user, $legalEntity, $authUserUUID, $this->isFirstLogin);
 
         auth('ehealth')->login($user);
+
+        // Dispatch event after successful login (at first do FirstLogin Synchronization here)
+        EhealthUserLoggedIn::dispatch($legalEntity, $this->isFirstLogin);
 
         if ($legalEntity) {
             Log::info(__('auth.login.success.user_auth', [], 'en'), ['User ID' => $user->id]);

--- a/app/Http/Middleware/Jobs/EnsureUserHasActiveSession.php
+++ b/app/Http/Middleware/Jobs/EnsureUserHasActiveSession.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware\Jobs;
+
+use Closure;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
+// use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * Job middleware to ensure user with active session exists before processing
+ *
+ * This middleware will:
+ * 1. Check if job has user property and legal entity
+ * 2. If user not found, try to find user with active session for the legal entity
+ * 3. If still no user found, retry job up to maxAttempts times
+ * 4. If max attempts reached, fail the job
+ * 5. If user found, set it on job and continue processing
+ */
+class EnsureUserHasActiveSession
+{
+    protected const array JOBS_POLICY_MAP = [
+        'DivisionSync' => ['policy' => 'viewAny', 'model' => '\App\Models\Division'],
+        'HealthcareServiceSync' => ['policy' => 'viewAny', 'model' => '\App\Models\HealthcareService'],
+    ];
+
+    /**
+     * Maximum number of attempts to find user with active session
+     *
+     * @var int
+     */
+    protected int $maxAttempts;
+
+    /**
+     * Delay in seconds between retry attempts
+     *
+     * @var int
+     */
+    protected int $retryDelay;
+
+    public function __construct(int $maxAttempts = 3, int $retryDelay = 3)
+    {
+        $this->maxAttempts = $maxAttempts;
+        $this->retryDelay = $retryDelay;
+    }
+
+    /**
+     * Process the queued job.
+     *
+     * @param mixed $job
+     * @param Closure $next
+     *
+     * @return mixed
+     */
+    public function handle($job, Closure $next)
+    {
+        // Check if the job has the required properties
+        if (!property_exists($job, 'user') || !property_exists($job, 'legalEntity')) {
+            return $next($job);
+        }
+
+        // If user is already set and valid, continue
+        if ($job->user instanceof User) {
+            return $next($job);
+        }
+
+        // Try to get user with active session
+        $user = $this->getUserWithActiveSession($job);
+
+        if (!$user) {
+            // Check if we've exceeded max attempts
+            if ($job->attempts() >= $this->maxAttempts) {
+                $message = "Max attempts ({$this->maxAttempts}) reached, no suitable user with active session found for legal entity {$job->legalEntity->id}";
+
+                echo $message . PHP_EOL;
+
+                Log::warning('Job failed due to missing user session', [
+                    'legal_entity_id' => $job->legalEntity->id,
+                    'attempts' => $job->attempts(),
+                    'max_attempts' => $this->maxAttempts,
+                    'job_class' => get_class($job)
+                ]);
+
+                $job->fail($message);
+
+                return;
+            }
+
+            echo "No suitable user with active session found for legal entity {$job->legalEntity->id}, retrying in {$this->retryDelay} seconds... (attempt {$job->attempts()}/{$this->maxAttempts})" . PHP_EOL;
+
+            $job->release($this->retryDelay);
+
+            return;
+        }
+
+        // Set the user and continue
+        $job->user = $user;
+
+        $job->user->unsetRelation('roles')->unsetRelation('permissions');
+
+        echo "Found user {$user->id} with active session for legal entity {$job->legalEntity->id}" . PHP_EOL;
+
+        return $next($job);
+    }
+
+    /**
+     * Get user with active session for the legal entity
+     *
+     * This method performs a complex database query to find users that meet two specific criteria:
+     * 1. User must be an employee of the specified legal entity
+     * 2. User must have an active session (record exists in sessions table)
+     *
+     * The query uses Eloquent's whereHas() and whereExists() methods for performance optimization:
+     * - whereHas('employees'): Uses LEFT JOIN to check user-employee relationship through employees table
+     * - whereExists(): Uses EXISTS subquery to check for session records without joining session data
+     *
+     * @param mixed $job The job instance containing legalEntity property
+     * @return User|null
+     */
+    protected function getUserWithActiveSession($job): ?User
+    {
+        // Execute complex query to find users matching both criteria
+        $users = User::whereHas('employees', function ($query) use ($job) {
+                // FIRST CRITERIA: User must be employee of this legal entity
+                // This creates a LEFT JOIN with employees table and filters by legal_entity_id
+                // SQL equivalent: LEFT JOIN employees ON users.id = employees.user_id WHERE employees.legal_entity_id = ?
+                $query->where('legal_entity_id', $job->legalEntity->id);
+            })
+            ->whereExists(function ($query) {
+                // SECOND CRITERIA: User must have active session
+                // This creates an EXISTS subquery to check sessions table
+                // Using SELECT 1 for performance - we only need to verify existence, not retrieve data
+                // SQL equivalent: EXISTS (SELECT 1 FROM sessions WHERE sessions.user_id = users.id)
+                $query->select(DB::raw(1))
+                    ->from('sessions')
+                    // whereColumn creates correlation between main query and subquery
+                    // This ensures we check sessions for the specific user from outer query
+                    ->whereColumn('sessions.user_id', 'users.id');
+            })
+            ->get();
+
+        echo "Found " . $users->count() . " users with active sessions for legal entity {$job->legalEntity->id}" . PHP_EOL;
+
+        // User that can be able to do synchronization
+        $userThatCanBeAble = null;
+
+        setPermissionsTeamId($job->legalEntity->id);
+
+        // Return first user from collection that can be able to do synchronization, or null if none found
+        foreach ($users as $user) {
+            // app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+            if (! $user->relationLoaded('roles')) {
+                $user->loadMissing('roles', 'permissions');
+            }
+
+            if ($this->checkJobPolicy($job, $user)) {
+                $userThatCanBeAble = $user;
+
+                break;
+            }
+        }
+
+        return $userThatCanBeAble;
+    }
+
+    /**
+     * Check if user has the required policy permissions for the specific job type
+     *
+     *
+     * @param mixed $job The job instance (must have getBatchName() method or BATCH_NAME constant)
+     * @param User $user The user to check permissions for
+     *
+     * @return bool True if user has required permissions, false otherwise
+     *
+     * @see static::JOBS_POLICY_MAP Array mapping job names to required policies and models
+     */
+    protected function checkJobPolicy($job, $user): bool
+    {
+        // Get BATCH_NAME using method (more flexible approach)
+        $batchName = method_exists($job, 'getBatchName') ? $job->getBatchName() : $job::BATCH_NAME;
+
+        if (empty($batchName) || !array_key_exists($batchName, static::JOBS_POLICY_MAP)) {
+            return false;
+        }
+
+        ['policy' => $policy, 'model' => $model] = static::JOBS_POLICY_MAP[$batchName] ?? [null, null];
+
+        if ($policy === null || $model === null) {
+            return false;
+        }
+
+        return $user->can($policy, $model);
+    }
+}

--- a/app/Jobs/DivisionSync.php
+++ b/app/Jobs/DivisionSync.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Core\EHealthJob;
+use App\Models\Division;
+use App\Classes\eHealth\EHealth;
+use App\Jobs\HealthcareServiceSync;
+use GuzzleHttp\Promise\PromiseInterface;
+use App\Classes\eHealth\EHealthResponse;
+use Illuminate\Queue\Middleware\RateLimited;
+
+class DivisionSync extends EHealthJob
+{
+    public const string BATCH_NAME = 'DivisionSync';
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        echo 'Starting DivisionSync for user:' . $this->user->id . ', legalEntity:' . $this->legalEntity->id . ', page:' . $this->page . PHP_EOL;
+
+        parent::handle();
+    }
+
+    protected function sendRequest(string $token): PromiseInterface|EHealthResponse
+    {
+        return EHealth::division()
+                ->withToken($token)
+                ->getMany(query: ['page' => $this->page]);
+    }
+
+    protected function processResponse(EHealthResponse $response): void
+    {
+        // Implement the logic to process the response and store/update data in the database
+    }
+
+    /**
+     * Get additional middleware configurations for the job.
+     *
+     * @return array Returns an array of middleware configurations to be applied to the job
+     */
+    protected function getAdditionalMiddleware(): array
+    {
+        return [
+            new RateLimited('ehealth-division-get')
+        ];
+    }
+}

--- a/app/Jobs/HealthcareServiceSync.php
+++ b/app/Jobs/HealthcareServiceSync.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Core\EHealthJob;
+use App\Classes\eHealth\EHealth;
+use App\Models\HealthcareService;
+use GuzzleHttp\Promise\PromiseInterface;
+use App\Classes\eHealth\EHealthResponse;
+use Illuminate\Queue\Middleware\RateLimited;
+
+class HealthcareServiceSync extends EHealthJob
+{
+    public const string BATCH_NAME = 'HealthcareServiceSync';
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        echo 'Starting HealthcareService Sync for user:' . $this->user->id . ', legalEntity:' . $this->legalEntity->id . ', page:' . $this->page . PHP_EOL;
+
+        parent::handle();
+    }
+
+    protected function sendRequest(string $token): PromiseInterface|EHealthResponse
+    {
+        return EHealth::healthcareService()
+                ->withToken($token)
+                ->getMany(query: ['page' => $this->page]);
+    }
+
+    protected function processResponse(EHealthResponse $response): void
+    {
+        // Implement the logic to process the response and store/update data in the database
+    }
+
+    /**
+     * Get additional middleware configurations for the job.
+     *
+     * @return array Returns an array of middleware configurations to be applied to the job
+     */
+    protected function getAdditionalMiddleware(): array
+    {
+        return [
+            new RateLimited('ehealth-division-get')
+        ];
+    }
+}

--- a/app/Listeners/FirstLoginOwnerSyncronization.php
+++ b/app/Listeners/FirstLoginOwnerSyncronization.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Listeners;
+
+use Throwable;
+use App\Core\EHealthBatch;
+use App\Jobs\DivisionSync;
+use App\Events\EhealthUserLoggedIn;
+use App\Jobs\HealthcareServiceSync;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class FirstLoginOwnerSyncronization implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * This listener will be placed on the 'sync' queue
+     *
+     * @var string|null
+     */
+    public $queue = 'sync';
+
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(EhealthUserLoggedIn $event): void
+    {
+        if (!$event->isFirstLogin) {
+            return;
+        }
+
+        echo 'First login synchronization started. ' . 'legalEntity:' . $event->legalEntity->id. PHP_EOL;
+
+        $healthcareServiceJob = new HealthcareServiceSync($event->legalEntity, isFirstLogin: true);
+
+        $initialJob = new DivisionSync($event->legalEntity, isFirstLogin: true, nextEntity: $healthcareServiceJob);
+
+        EHealthBatch::createWithLegalEntity([$initialJob], 'FirstLoginSync', $event->legalEntity->id, 'sync');
+    }
+
+    /**
+     * Handle a job failure.
+     *
+     * @param EhealthUserLoggedIn $event
+     * @param Throwable $exception
+     * @return void
+     */
+    public function failed(EhealthUserLoggedIn $event, Throwable $exception): void
+    {
+        $errorMessage = "FirstLoginOwnerSyncronization failed for legal entity ID: {$event->legalEntity->id}";
+        $errorDetails = "Error: {$exception->getMessage()}";
+
+        // Log the error
+        Log::error($errorMessage, [
+            'legal_entity_id' => $event->legalEntity->id,
+            'error_message' => $exception->getMessage(),
+            'trace' => $exception->getTraceAsString(),
+            'listener' => self::class,
+        ]);
+
+        // Output to console
+        echo $errorMessage . PHP_EOL;
+        echo $errorDetails . PHP_EOL;
+        echo "Stack trace: " . $exception->getTraceAsString() . PHP_EOL;
+    }
+}

--- a/app/Listeners/OnRegularLoginSyncronization.php
+++ b/app/Listeners/OnRegularLoginSyncronization.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Core\EHealthBatch;
+use App\Events\EhealthUserLoggedIn;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class OnRegularLoginSyncronization implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * This listener will be placed on the 'sync' queue
+     *
+     * @var string|null
+     */
+    public $queue = 'sync';
+
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(EhealthUserLoggedIn $event): void
+    {
+        if ($event->isFirstLogin) {
+            return;
+        }
+
+        echo 'Regular login synchronization checking for ' . ', legalEntity:' . $event->legalEntity->id . PHP_EOL;
+
+        // Find all failed batches for this legal entity and retry them
+        $failedBatches = EHealthBatch::findFailedByLegalEntity($event->legalEntity->id, 'ASC');
+
+        foreach ($failedBatches as $batch) {
+            echo 'Found related batch: ' . $batch->name . ' id: ' . $batch->id . PHP_EOL;
+
+            Artisan::call('queue:retry-batch', ['id' => $batch->id]);
+        }
+
+    }
+}

--- a/app/Policies/HealthcareServicePolicy.php
+++ b/app/Policies/HealthcareServicePolicy.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Enums\Status;
+use App\Models\LegalEntity;
+use App\Models\HealthcareService;
+use Illuminate\Auth\Access\Response;
+
+// TODO: need to more test and review this policy
+class HealthcareServicePolicy
+{
+    /**
+     * User allowed to view the list of healthcare services
+     */
+    public function viewAny(User $user): Response
+    {
+        if ($user->cannot('healthcare_service:read')) {
+            return Response::denyWithStatus(403);
+        }
+
+        return Response::allow();
+    }
+
+    /**
+     * User allow to create the Division
+     */
+    public function create(User $user): Response
+    {
+        if ($user->cannot('healthcare_service:write')) {
+            return Response::denyWithStatus(403);
+        }
+
+        return Response::allow();
+    }
+
+    /**
+     * User allow to delete the Division's draft record fromm the DB
+     */
+    public function delete(User $user, HealthcareService $healthcareService): Response
+    {
+        // Only HealthcareServices with DRAFT status can be deleted
+        if ($healthcareService->status !== Status::DRAFT) {
+            return Response::deny();
+        }
+
+        return Response::allow();
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, HealthcareService $healthcareService, ?LegalEntity $legalEntity = null): Response|bool
+    {
+        if (is_null($legalEntity)) {
+            $legalEntity = legalEntity();
+        }
+
+        // If got null instaed HealthcareService model
+        if (empty($healthcareService)) {
+            return Response::denyWithStatus(404);
+        }
+
+        // Should belong to the same legal entity
+        if ($healthcareService->legal_entity_id !== (int) $legalEntity->id) {
+            return Response::denyWithStatus(404);
+        }
+
+        if ($user->cannot('healthcare_service:write')) {
+            return Response::denyWithStatus(403);
+        }
+
+        // Inactive healthcare services cannot be updated
+        if ($healthcareService->status === Status::INACTIVE) {
+            return Response::deny();
+        }
+
+        return Response::allow();
+    }
+
+    /**
+     * Determine whether the user can activate the division.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Division  $division
+     *
+     * @return bool
+     */
+    public function activate(User $user, HealthcareService $healthcareService): Response
+    {
+        if ($user->cannot('healthcare_service:write')) {
+            return Response::denyWithStatus(403);
+        }
+
+        // Some healthcare services cannot be activated
+        if (
+            $healthcareService->status === Status::ACTIVE ||
+            $healthcareService->status === Status::DRAFT ||
+            $healthcareService->status === Status::UNSYNCED
+        ) {
+            return Response::deny();
+        }
+
+        return Response::allow();
+    }
+
+    /**
+     * Determine whether the user can deactivate the division.
+     *
+     * @param  \App\Models\User  $user  The user attempting the action
+     * @param  \App\Models\Division  $division  The division to be deactivated
+     *
+     * @return bool  True if user can deactivate the division, false otherwise
+     */
+    public function deactivate(User $user, HealthcareService $healthcareService): Response
+    {
+        if ($user->cannot('healthcare_service:write')) {
+            return Response::denyWithStatus(403);
+        }
+
+        // Some healthcare services cannot be deactivated
+        if (
+            $healthcareService->status === Status::INACTIVE ||
+            $healthcareService->status === Status::DRAFT ||
+            $healthcareService->status === Status::UNSYNCED
+        ) {
+            return Response::deny();
+        }
+
+        return Response::allow();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,7 +34,14 @@ class AppServiceProvider extends ServiceProvider
         DB::prohibitDestructiveCommands($this->app->isProduction());
 
         RateLimiter::for('ehealth-employee-get', function (object $job) {
-            return Limit::perMinute(30)->by($job->user->id);
+            return Limit::perMinute(config('ehealth.rate_limit.employee_request'))->by($job->user->id);
         });
+
+        RateLimiter::for('ehealth-division-get', function (object $job) {
+            echo "Rate limiter set for user: " . $job->user->id . PHP_EOL;
+            return Limit::perMinute(config('ehealth.rate_limit.division_request'))->by($job->user->id);
+        });
+
+        // RateLimiter::for('ehealth-division-get', fn (object $job) => Limit::perMinute(50)->by($job->user->id));
     }
 }

--- a/app/Repositories/DivisionRepository.php
+++ b/app/Repositories/DivisionRepository.php
@@ -28,8 +28,8 @@ class DivisionRepository
     {
         $legalEntity ??= legalEntity();
 
-        DB::transaction(function() use($divisionsList) {
-            $uspertData = DivisionApi::normalizeResponseDataForUpsert($divisionsList);
+        DB::transaction(function() use($divisionsList, $legalEntity) {
+            $uspertData = DivisionApi::normalizeResponseDataForUpsert($divisionsList, $legalEntity);
 
             // At first save all the Divisions to teh DB
             Division::upsert($uspertData, uniqueBy: ['uuid'], update: new Division()->getFillable());

--- a/app/Repositories/HealthcareServiceRepository.php
+++ b/app/Repositories/HealthcareServiceRepository.php
@@ -6,6 +6,7 @@ use Exception;
 use App\Models\Division;
 use App\Models\HealthcareService;
 use Illuminate\Support\Facades\DB;
+use App\Classes\eHealth\Api\HealthcareService as HealthcareServiceApi;
 
 class HealthcareServiceRepository
 {
@@ -43,6 +44,25 @@ class HealthcareServiceRepository
             foreach ($responseList as $responseItem) {
                 $this->saveHealthcareServiceResponseData($responseItem);
             }
+        });
+    }
+
+    /**
+     * Saves all healthcare services from API response using batch upsert operation.
+     *
+     * @param array $healthcareServicesList Raw healthcare services data from eHealth API
+     *
+     * @return void
+     *
+     * @throws Exception If database transaction fails
+     */
+    public function saveHealthcareServiceAll(array $healthcareServicesList): void
+    {
+        DB::transaction(function() use($healthcareServicesList) {
+            $uspertData = HealthcareServiceApi::normalizeResponseDataForUpsert($healthcareServicesList);
+
+            // At first save all the Divisions to teh DB
+            HealthcareService::upsert($uspertData, uniqueBy: ['uuid'], update: new HealthcareService()->getFillable());
         });
     }
 

--- a/config/ehealth.php
+++ b/config/ehealth.php
@@ -60,7 +60,8 @@ return [
         ],
     ],
     'rate_limit' => [
-        'employee_request' => 20
+        'employee_request' => 30,
+        'division_request' => 50
     ],
     'employee_type' => [
         'OWNER' => [

--- a/database/migrations/2023_12_21_120545_create_legal_entities_table.php
+++ b/database/migrations/2023_12_21_120545_create_legal_entities_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\JobStatus;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -33,6 +34,12 @@ return new class extends Migration
             $table->string('client_id')->nullable();
             $table->string('client_secret')->nullable();
             $table->string('website')->nullable();
+            $table->enum('sync_status', JobStatus::values())->nullable();
+            $table->enum('division_sync_status', JobStatus::values())->nullable();
+            $table->enum('hcs_sync_status', JobStatus::values())->nullable();
+            $table->enum('employee_sync_status', JobStatus::values())->nullable();
+            $table->enum('license_sync_status', JobStatus::values())->nullable();
+            $table->enum('document_sync_status', JobStatus::values())->nullable();
             $table->timestamp('inserted_at')->nullable();
             $table->timestamps();
         });

--- a/database/migrations/2025_09_13_165519_add_legal_entity_id_to_job_batches_table.php
+++ b/database/migrations/2025_09_13_165519_add_legal_entity_id_to_job_batches_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('job_batches', function (Blueprint $table) {
+            // Add legal_entity_id field to track which legal entity the batch belongs to
+            $table->unsignedBigInteger('legal_entity_id')->nullable()->after('options');
+
+            // Add foreign key constraint to legal_entities table
+            $table->foreign('legal_entity_id')
+                  ->references('id')
+                  ->on('legal_entities')
+                  ->onDelete('set null'); // Set to null if legal entity is deleted
+
+            // Add index for better query performance
+            $table->index(['legal_entity_id', 'created_at'], 'idx_job_batches_legal_entity_created');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('job_batches', function (Blueprint $table) {
+            // Drop foreign key constraint first
+            $table->dropForeign(['legal_entity_id']);
+
+            // Drop index
+            $table->dropIndex('idx_job_batches_legal_entity_created');
+
+            // Drop the column
+            $table->dropColumn('legal_entity_id');
+        });
+    }
+};


### PR DESCRIPTION
This PR concerns to the #248 ISSUE

Що було зроблено:
- додано подію EhealthUserLoggedIn, яка запускається під час входу користувача в систему (після логіну);
- додано лістенер FirstLoginOwnerSyncronization, який прослуховує подію EhealthUserLoggedIn і виконується лише при першому входу власника в систему;
- додано лістенер OnRegularLoginSyncronization, який прослуховує подію EhealthUserLoggedIn і викликається при другому і подальших наступних входах будь-якого користувача в систему (має відновлювати призупинений процес синхронізації - будь-якої (якщо на те є відповідні дозволи));
- додано клас-шаблон для завдань;
- доданj класи-завдання для синхронізації сутностей Division й HealthcareService;
- додано автоматичне визначення користувача, від якого допускається проводити синхронізацію (middleware);
- додано роботу з політиками які дозволяють визначати чи дозволено даному користувачу здійснювати синхронізацію даної (конкретної) сутності;
- додано атрибути-статуси щодо виконання синхронізації по кожній сутності в таблицю legal_entities;
- додано функціонал відновлення призупенених робіт після входу користувача з відповідними дозволами.