### PR TITLE
I253 permissions update

### DIFF
--- a/app/Classes/eHealth/Api/Employee.php
+++ b/app/Classes/eHealth/Api/Employee.php
@@ -7,7 +7,6 @@ namespace App\Classes\eHealth\Api;
 use App\Classes\eHealth\EHealthRequest;
 use App\Classes\eHealth\EHealthResponse;
 use App\Core\Arr;
-use App\Models\Employee\EmployeeRequest;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Log;
@@ -117,19 +116,6 @@ class Employee extends EHealthRequest
 
         $employeeTypeKey = strtolower($transformedData['employee_type'] ?? '');
         $doctorTypes = implode(',', config('ehealth.doctors_type', []));
-
-        // =================================================================================
-        //  COMMENT REGARDING DATA VALIDATION FROM E-HEALTH
-        // =================================================================================
-        //  The validation logic below has been relaxed compared to the original implementation.
-        //  Reason: The E-Health API sometimes returns incomplete or logically incorrect data.
-        //  For example, for documents, the issue date (issued_at) may be missing,
-        //  and for qualifications, the expiration date (valid_to) may be earlier than the issue date.
-        //
-        //  To avoid synchronization failures due to such data issues on the E-Health side,
-        //  we accept this data but leave this comment as a warning.
-        //  In an ideal world, these rules should be stricter (e.g., 'required' instead of 'nullable').
-        // =================================================================================
 
         $rules = [
             'uuid' => 'required|uuid',
@@ -276,92 +262,5 @@ class Employee extends EHealthRequest
         }
 
         return $replaced;
-    }
-
-    /**
-     * Prepares data for the Party model from an API response.
-     */
-    public static function mapPartyData(array $apiPartyData): array
-    {
-        $partyApiKeys = ['id', 'first_name', 'last_name', 'second_name', 'birth_date', 'gender', 'no_tax_id', 'tax_id', 'email'];
-        $partyData = array_intersect_key($apiPartyData, array_flip($partyApiKeys));
-
-        if (isset($partyData['id'])) {
-            $partyData['uuid'] = $partyData['id'];
-            unset($partyData['id']);
-        }
-
-        return $partyData;
-    }
-
-    /**
-     * Prepares a complete data structure for creating a new Employee
-     * by combining data from the signed Revision and the approved API response.
-     *
-     * @param EmployeeRequest $employeeRequest The local request containing the revision.
-     * @param array           $approvedData    The final, confirmed data from the E-Health API.
-     *
-     * @return array A structured array with data for employee, party, doctor, etc.
-     */
-    public static function mapCreate(EmployeeRequest $employeeRequest, array $approvedData): array
-    {
-        // THE SOURCE OF TRUTH: Data from the revision, which the user signed.
-        $revisionData = $employeeRequest->revision->data;
-
-        // 1. Prepare Employee data
-        $employeeData = [
-            // Data from the Revision (what user signed)
-            'position' => $revisionData['employee_request_data']['position'],
-            'employee_type' => $revisionData['employee_request_data']['employee_type'],
-            'start_date' => $revisionData['employee_request_data']['start_date'],
-            'end_date' => $revisionData['employee_request_data']['end_date'],
-            'division_id' => $revisionData['employee_request_data']['division_id'],
-
-            // Data from existing relationships
-            'legal_entity_id' => $employeeRequest->legal_entity_id,
-            'legal_entity_uuid' => $employeeRequest->legal_entity_uuid,
-            'inserted_at' => now(),
-            'party_id' => $employeeRequest->party_id,
-            'user_id' => $employeeRequest->party->user_id,
-
-            // Final, confirmed data from the live E-Health response
-            'uuid' => $approvedData['uuid'],
-            'status' => $approvedData['status'],
-            'is_active' => $approvedData['is_active'] ?? true,
-        ];
-
-        // 2. Prepare related data using existing mappers
-        $partyData = self::mapPartyData($revisionData['party'] ?? []);
-        $doctorData = $revisionData['doctor'] ?? []; // This already contains nested structure
-
-        // 3. Return a structured payload
-        return [
-            'employee' => $employeeData,
-            'party' => $partyData,
-            'doctor' => $doctorData,
-            // We can also return documents and phones directly from revision
-            'documents' => $revisionData['documents'] ?? [],
-            'phones' => $revisionData['phones'] ?? [],
-        ];
-    }
-
-    /**
-     * Prepares the nested data structure for a Revision from flat form data.
-     */
-    public static function mapRevisionData(array $flatData): array
-    {
-        $employeeChunk = Arr::only($flatData, ['position', 'employee_type', 'start_date', 'end_date', 'division_id']);
-        $partyChunk = Arr::only($flatData, ['last_name', 'first_name', 'second_name', 'gender', 'birth_date', 'tax_id', 'no_tax_id', 'email', 'working_experience', 'about_myself']);
-        $documentsChunk = $flatData['documents'] ?? [];
-        $phonesChunk = $flatData['phones'] ?? [];
-        $doctorChunk = $flatData['doctor'] ?? [];
-
-        return [
-            'employee_request_data' => $employeeChunk,
-            'party' => $partyChunk,
-            'documents' => $documentsChunk,
-            'phones' => $phonesChunk,
-            'doctor' => $doctorChunk,
-        ];
     }
 }

--- a/app/Classes/eHealth/Api/Employee.php
+++ b/app/Classes/eHealth/Api/Employee.php
@@ -158,10 +158,8 @@ class Employee extends EHealthRequest
             'party.documents' => 'required|array|min:1',
             'party.documents.*.type' => 'required|string',
             'party.documents.*.number' => 'required|string',
-//            'party.documents.*.issued_by' => 'sometimes|string',
-            'party.documents.*.issued_by' => 'sometimes|nullable|string',
-            //            'party.documents.*.issued_at' => 'required|date_format:Y-m-d',
-            'party.documents.*.issued_at' => 'nullable|date_format:Y-m-d',
+            'party.documents.*.issued_by' => 'sometimes|string',
+            'party.documents.*.issued_at' => 'required|date_format:Y-m-d',
         ];
 
         if (!empty($employeeTypeKey)) {

--- a/app/Classes/eHealth/Api/Employee.php
+++ b/app/Classes/eHealth/Api/Employee.php
@@ -7,6 +7,7 @@ namespace App\Classes\eHealth\Api;
 use App\Classes\eHealth\EHealthRequest;
 use App\Classes\eHealth\EHealthResponse;
 use App\Core\Arr;
+use App\Models\Employee\EmployeeRequest;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Log;
@@ -280,26 +281,6 @@ class Employee extends EHealthRequest
     }
 
     /**
-     * Prepares data for the Employee model from an API response.
-     */
-    public static function mapEmployeeData(array $apiData, EmployeeRequest $employeeRequest): array
-    {
-        $employeeApiKeys = ['id', 'status', 'position', 'employee_type', 'start_date', 'end_date', 'is_active'];
-        $employeeData = array_intersect_key($apiData, array_flip($employeeApiKeys));
-
-        $employeeData['uuid'] = $employeeData['id'];
-        unset($employeeData['id']);
-
-        return array_merge($employeeData, [
-            'legal_entity_uuid' => $apiData['legal_entity']['id'] ?? null,
-            'legal_entity_id' => $employeeRequest->legal_entity_id,
-            'party_id' => $employeeRequest->party_id,
-            'user_id' => $employeeRequest->party->user_id,
-            'division_id' => $employeeRequest->division_id,
-        ]);
-    }
-
-    /**
      * Prepares data for the Party model from an API response.
      */
     public static function mapPartyData(array $apiPartyData): array
@@ -316,13 +297,54 @@ class Employee extends EHealthRequest
     }
 
     /**
-     * Prepares doctor-specific data from an API response.
+     * Prepares a complete data structure for creating a new Employee
+     * by combining data from the signed Revision and the approved API response.
+     *
+     * @param EmployeeRequest $employeeRequest The local request containing the revision.
+     * @param array           $approvedData    The final, confirmed data from the E-Health API.
+     *
+     * @return array A structured array with data for employee, party, doctor, etc.
      */
-    public static function mapDoctorData(array $apiData): array
+    public static function mapCreate(EmployeeRequest $employeeRequest, array $approvedData): array
     {
-        $doctorDataKey = strtolower($apiData['employee_type'] ?? '');
+        // THE SOURCE OF TRUTH: Data from the revision, which the user signed.
+        $revisionData = $employeeRequest->revision->data;
 
-        return $apiData[$doctorDataKey] ?? [];
+        // 1. Prepare Employee data
+        $employeeData = [
+            // Data from the Revision (what user signed)
+            'position' => $revisionData['employee_request_data']['position'],
+            'employee_type' => $revisionData['employee_request_data']['employee_type'],
+            'start_date' => $revisionData['employee_request_data']['start_date'],
+            'end_date' => $revisionData['employee_request_data']['end_date'],
+            'division_id' => $revisionData['employee_request_data']['division_id'],
+
+            // Data from existing relationships
+            'legal_entity_id' => $employeeRequest->legal_entity_id,
+            'legal_entity_uuid' => $employeeRequest->legal_entity_uuid,
+            'inserted_at' => now(),
+            'party_id' => $employeeRequest->party_id,
+            'user_id' => $employeeRequest->party->user_id,
+
+            // Final, confirmed data from the live E-Health response
+            'uuid' => $approvedData['uuid'],
+            'status' => $approvedData['status'],
+            'is_active' => $approvedData['is_active'] ?? true,
+        ];
+
+        // 2. Prepare related data using existing mappers
+        $partyData = self::mapPartyData($revisionData['party'] ?? []);
+        $doctorData = $revisionData['doctor'] ?? []; // This already contains nested structure
+
+        // 3. Return a structured payload
+        return [
+            'employee' => $employeeData,
+            'party' => $partyData,
+            'doctor' => $doctorData,
+            // We can also return documents and phones directly from revision
+            'documents' => $revisionData['documents'] ?? [],
+            'phones' => $revisionData['phones'] ?? [],
+        ];
     }
 
     /**

--- a/app/Classes/eHealth/Api/EmployeeRequest.php
+++ b/app/Classes/eHealth/Api/EmployeeRequest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Classes\eHealth\Api;
 
 use App\Classes\eHealth\EHealthRequest;
-use App\Exceptions\EHealth\EHealthValidationException;
+use App\Core\Arr;
 use Illuminate\Http\Client\ConnectionException;
 use RuntimeException;
 
@@ -23,7 +23,7 @@ class EmployeeRequest extends EHealthRequest
      * @param string $signedContent The base64 encoded signed string.
      *
      * @return array The response data from eHealth on success.
-     * @throws EHealthValidationException|ConnectionException|RuntimeException
+     * @throws ConnectionException|RuntimeException
      */
     public function create(string $signedContent): array
     {
@@ -34,6 +34,42 @@ class EmployeeRequest extends EHealthRequest
         return [
             'id' => $response->json('data.id'),
             'ehealth_response' => $response->json(),
+        ];
+    }
+
+    public static function mapCreate(EmployeeRequest $employeeRequest, array $approvedData): array
+    {
+        $revisionData = $employeeRequest->revision->data;
+
+        $employeeData = array_merge(
+            $revisionData['employee_request_data'] ?? [],
+            [
+                'legal_entity_id' => $employeeRequest->legal_entity_id,
+                'legal_entity_uuid' => $employeeRequest->legal_entity_uuid,
+                'party_id' => $employeeRequest->party_id,
+                'user_id' => $employeeRequest->party->user_id,
+                'inserted_at' => now(),
+            ],
+            [
+                'uuid' => $approvedData['uuid'],
+                'status' => $approvedData['status'],
+                'is_active' => $approvedData['is_active'] ?? true,
+            ]
+        );
+
+        $partyData = $revisionData['party'] ?? [];
+        $partyData['uuid'] = Arr::get($approvedData, 'party.uuid');
+
+        $phonesData = $revisionData['phones'] ?? [];
+        $documentsData = $revisionData['documents'] ?? [];
+        $doctorData = $revisionData['doctor'] ?? [];
+
+        return [
+            'employee' => $employeeData,
+            'party' => $partyData,
+            'phones' => $phonesData,
+            'documents' => $documentsData,
+            'doctor' => $doctorData,
         ];
     }
 

--- a/app/Classes/eHealth/Api/EmployeeRequest.php
+++ b/app/Classes/eHealth/Api/EmployeeRequest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Classes\eHealth\Api;
 
 use App\Classes\eHealth\EHealthRequest;
-use App\Core\Arr;
 use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Arr;
 use RuntimeException;
 
 class EmployeeRequest extends EHealthRequest
@@ -37,39 +37,21 @@ class EmployeeRequest extends EHealthRequest
         ];
     }
 
-    public static function mapCreate(EmployeeRequest $employeeRequest, array $approvedData): array
+    public function mapCreate(array $sourceData): array
     {
-        $revisionData = $employeeRequest->revision->data;
 
-        $employeeData = array_merge(
-            $revisionData['employee_request_data'] ?? [],
-            [
-                'legal_entity_id' => $employeeRequest->legal_entity_id,
-                'legal_entity_uuid' => $employeeRequest->legal_entity_uuid,
-                'party_id' => $employeeRequest->party_id,
-                'user_id' => $employeeRequest->party->user_id,
-                'inserted_at' => now(),
-            ],
-            [
-                'uuid' => $approvedData['uuid'],
-                'status' => $approvedData['status'],
-                'is_active' => $approvedData['is_active'] ?? true,
-            ]
-        );
-
-        $partyData = $revisionData['party'] ?? [];
-        $partyData['uuid'] = Arr::get($approvedData, 'party.uuid');
-
-        $phonesData = $revisionData['phones'] ?? [];
-        $documentsData = $revisionData['documents'] ?? [];
-        $doctorData = $revisionData['doctor'] ?? [];
+        $partyData = $sourceData['party'] ?? [];
+        $doctorData = $sourceData['doctor'] ?? [];
 
         return [
-            'employee' => $employeeData,
-            'party' => $partyData,
-            'phones' => $phonesData,
-            'documents' => $documentsData,
-            'doctor' => $doctorData,
+            'employee' => Arr::get($sourceData, 'employee_request_data', []),
+            'party' => Arr::except($partyData, ['documents', 'phones']),
+            'documents' => $sourceData['documents'] ?? [],
+            'phones' => $sourceData['phones'] ?? [],
+            'educations' => $doctorData['educations'] ?? [],
+            'specialities' => $doctorData['specialities'] ?? [],
+            'qualifications' => $doctorData['qualifications'] ?? [],
+            'science_degree' => $doctorData['science_degree'] ?? null,
         ];
     }
 

--- a/app/Classes/eHealth/EHealth.php
+++ b/app/Classes/eHealth/EHealth.php
@@ -7,6 +7,7 @@ namespace App\Classes\eHealth;
 use App\Classes\eHealth\Api\Declaration;
 use App\Classes\eHealth\Api\DeclarationRequest;
 use App\Classes\eHealth\Api\Employee;
+use App\Classes\eHealth\Api\EmployeeRequest;
 use App\Classes\eHealth\Api\License;
 use App\Classes\eHealth\Api\Job;
 use App\Classes\eHealth\Api\Division;
@@ -65,5 +66,10 @@ final class EHealth
     public static function employee(): Employee
     {
         return app(Employee::class);
+    }
+
+    public static function employeeRequest(): EmployeeRequest
+    {
+        return app(EmployeeRequest::class);
     }
 }

--- a/app/Exceptions/EHealth/EHealthValidationException.php
+++ b/app/Exceptions/EHealth/EHealthValidationException.php
@@ -6,7 +6,6 @@ namespace App\Exceptions\EHealth;
 
 use App\Core\Arr as AppArr;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Log;
 
 class EHealthValidationException extends EHealthException
 {
@@ -15,6 +14,11 @@ class EHealthValidationException extends EHealthException
         parent::__construct('eHealth API returned a validation error.');
     }
 
+    /**
+     * Get the full details of the exception.
+     *
+     * @return array
+     */
     public function getDetails(): array
     {
         return $this->details;
@@ -22,13 +26,33 @@ class EHealthValidationException extends EHealthException
 
     /**
      * Get the translated error message based on eHealth details.
-     * Uses existing translation files for attributes and messages.
+     *
+     * @return string
      */
     public function getTranslatedMessage(): string
     {
+        $eHealthFieldTranslations = [
+            'party.first_name' => __('forms.first_name'),
+            'party.last_name' => __('forms.last_name'),
+            'party.second_name' => __('forms.second_name'),
+            'party.birth_date' => __('forms.birth_date'),
+            'party.tax_id' => __('forms.tax_id'),
+            'party.working_experience' => __('forms.working_experience'),
+            'doctor' => __('forms.doctor_data'),
+            'start_date' => __('forms.start_date_work'),
+            'employee_type' => __('forms.role'),
+            'position' => __('forms.position'),
+            'employee_request' => __('forms.employee_requests'),
+            'doctor.science_degree' => __('forms.science_degree'),
+            'party.documents.[0].number' => __('forms.document_number'),
+            'doctor.qualifications' => __('forms.qualifications'),
+            'doctor.specialities' => __('forms.specialities'),
+            'doctor.specialities.speciality_officio' => __('forms.speciality_officio'),
+        ];
+
         $invalidErrors = Arr::get($this->details, 'error.invalid') ?? Arr::get($this->details, 'invalid') ?? [];
 
-        $errorList = collect($invalidErrors)->map(function ($detail) {
+        $errorList = collect($invalidErrors)->map(function ($detail) use ($eHealthFieldTranslations) {
             $eHealthKey = AppArr::get($detail, 'entry') ?? AppArr::get($detail, 'param') ?? 'unknown';
             $message = AppArr::get($detail, 'rules.0.description') ?? AppArr::get($detail, 'msg') ?? '';
             $ruleName = AppArr::get($detail, 'rules.0.rule');
@@ -38,41 +62,38 @@ class EHealthValidationException extends EHealthException
             }
 
             $eHealthKey = str_replace(['$.', 'employee_request.'], '', $eHealthKey);
+            $translatedKey = $eHealthFieldTranslations[$eHealthKey] ?? $eHealthKey;
 
-            $translatedKey = trans('validation.attributes.' . $eHealthKey, [], 'uk');
-            if ($translatedKey === 'validation.attributes.' . $eHealthKey) {
-                $translatedKey = trans('forms.' . $eHealthKey, [], 'uk');
+            $translatedMessage = '';
+
+            if (str_contains($message, 'employee doesn\'t have speciality with active speciality_officio')) {
+                $translatedMessage = __('errors.ehealth.messages.employee doesn\'t have speciality with active speciality_officio');
+            } elseif (str_contains($message, 'speciality') && str_contains($message, ' with active speciality_officio is not allowed for doctor')) {
+                preg_match('/speciality (.+?) with active speciality_officio is not allowed for doctor/', $message, $matches);
+                $specialityName = $matches[1] ?? '';
+                $translatedMessage = __('errors.ehealth.messages.speciality_officio_not_allowed', ['speciality' => $specialityName]);
+            } elseif (str_contains($message, 'speciality') && str_contains($message, 'not allowed for doctor')) {
+                $translatedMessage = __('errors.ehealth.messages.speciality not allowed for doctor');
+            } elseif (str_contains($message, 'type mismatch')) {
+                $translatedMessage = __('errors.ehealth.messages.type mismatch. Expected integer but got string');
             }
 
-            $translatedMessage = $this->findTranslationForMessage($message, $ruleName);
+            if (empty($translatedMessage) && !empty($ruleName)) {
+                $translatedMessage = __('errors.ehealth.messages.' . $ruleName);
+                if ($translatedMessage === 'errors.ehealth.messages.' . $ruleName) {
+                    $translatedMessage = $message;
+                }
+            }
+
+            if (empty($translatedMessage)) {
+                $translatedMessage = __('errors.ehealth.messages.untranslated_error_message', ['message' => $message]);
+            }
 
             return "{$translatedKey}: {$translatedMessage}";
         })->filter()->implode("\n");
 
-        return trans('errors.ehealth.validation_error_header') . "\n" . $errorList;
-    }
+        $header = __('errors.ehealth.validation_error_header');
 
-    /**
-     * Finds the most appropriate translation for a given eHealth error message.
-     */
-    private function findTranslationForMessage(string $message, ?string $ruleName): string
-    {
-
-        if (str_contains($message, 'speciality') && str_contains($message, ' with active speciality_officio is not allowed for doctor')) {
-            preg_match('/speciality (.+?) with active speciality_officio is not allowed for doctor/', $message, $matches);
-            return trans('errors.ehealth.messages.speciality_officio_not_allowed', ['speciality' => $matches[1] ?? '']);
-        }
-
-        $key = $ruleName ?? $message;
-        if (trans()->has('errors.ehealth.messages.' . $key)) {
-            return trans('errors.ehealth.messages.' . $key);
-        }
-
-        Log::warning("Untranslated eHealth error message found.", [
-            'original_message' => $message,
-            'rule_name' => $ruleName,
-        ]);
-
-        return $message;
+        return "{$header}\n{$errorList}";
     }
 }

--- a/app/Exceptions/EHealth/EHealthValidationException.php
+++ b/app/Exceptions/EHealth/EHealthValidationException.php
@@ -6,6 +6,7 @@ namespace App\Exceptions\EHealth;
 
 use App\Core\Arr as AppArr;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 
 class EHealthValidationException extends EHealthException
 {
@@ -14,11 +15,6 @@ class EHealthValidationException extends EHealthException
         parent::__construct('eHealth API returned a validation error.');
     }
 
-    /**
-     * Get the full details of the exception.
-     *
-     * @return array
-     */
     public function getDetails(): array
     {
         return $this->details;
@@ -26,33 +22,13 @@ class EHealthValidationException extends EHealthException
 
     /**
      * Get the translated error message based on eHealth details.
-     *
-     * @return string
+     * Uses existing translation files for attributes and messages.
      */
     public function getTranslatedMessage(): string
     {
-        $eHealthFieldTranslations = [
-            'party.first_name' => __('forms.first_name'),
-            'party.last_name' => __('forms.last_name'),
-            'party.second_name' => __('forms.second_name'),
-            'party.birth_date' => __('forms.birth_date'),
-            'party.tax_id' => __('forms.tax_id'),
-            'party.working_experience' => __('forms.working_experience'),
-            'doctor' => __('forms.doctor_data'),
-            'start_date' => __('forms.start_date_work'),
-            'employee_type' => __('forms.role'),
-            'position' => __('forms.position'),
-            'employee_request' => __('forms.employee_requests'),
-            'doctor.science_degree' => __('forms.science_degree'),
-            'party.documents.[0].number' => __('forms.document_number'),
-            'doctor.qualifications' => __('forms.qualifications'),
-            'doctor.specialities' => __('forms.specialities'),
-            'doctor.specialities.speciality_officio' => __('forms.speciality_officio'),
-        ];
-
         $invalidErrors = Arr::get($this->details, 'error.invalid') ?? Arr::get($this->details, 'invalid') ?? [];
 
-        $errorList = collect($invalidErrors)->map(function ($detail) use ($eHealthFieldTranslations) {
+        $errorList = collect($invalidErrors)->map(function ($detail) {
             $eHealthKey = AppArr::get($detail, 'entry') ?? AppArr::get($detail, 'param') ?? 'unknown';
             $message = AppArr::get($detail, 'rules.0.description') ?? AppArr::get($detail, 'msg') ?? '';
             $ruleName = AppArr::get($detail, 'rules.0.rule');
@@ -62,38 +38,41 @@ class EHealthValidationException extends EHealthException
             }
 
             $eHealthKey = str_replace(['$.', 'employee_request.'], '', $eHealthKey);
-            $translatedKey = $eHealthFieldTranslations[$eHealthKey] ?? $eHealthKey;
 
-            $translatedMessage = '';
-
-            if (str_contains($message, 'employee doesn\'t have speciality with active speciality_officio')) {
-                $translatedMessage = __('errors.ehealth.messages.employee doesn\'t have speciality with active speciality_officio');
-            } elseif (str_contains($message, 'speciality') && str_contains($message, ' with active speciality_officio is not allowed for doctor')) {
-                preg_match('/speciality (.+?) with active speciality_officio is not allowed for doctor/', $message, $matches);
-                $specialityName = $matches[1] ?? '';
-                $translatedMessage = __('errors.ehealth.messages.speciality_officio_not_allowed', ['speciality' => $specialityName]);
-            } elseif (str_contains($message, 'speciality') && str_contains($message, 'not allowed for doctor')) {
-                $translatedMessage = __('errors.ehealth.messages.speciality not allowed for doctor');
-            } elseif (str_contains($message, 'type mismatch')) {
-                $translatedMessage = __('errors.ehealth.messages.type mismatch. Expected integer but got string');
+            $translatedKey = trans('validation.attributes.' . $eHealthKey, [], 'uk');
+            if ($translatedKey === 'validation.attributes.' . $eHealthKey) {
+                $translatedKey = trans('forms.' . $eHealthKey, [], 'uk');
             }
 
-            if (empty($translatedMessage) && !empty($ruleName)) {
-                $translatedMessage = __('errors.ehealth.messages.' . $ruleName);
-                if ($translatedMessage === 'errors.ehealth.messages.' . $ruleName) {
-                    $translatedMessage = $message;
-                }
-            }
-
-            if (empty($translatedMessage)) {
-                $translatedMessage = __('errors.ehealth.messages.untranslated_error_message', ['message' => $message]);
-            }
+            $translatedMessage = $this->findTranslationForMessage($message, $ruleName);
 
             return "{$translatedKey}: {$translatedMessage}";
         })->filter()->implode("\n");
 
-        $header = __('errors.ehealth.validation_error_header');
+        return trans('errors.ehealth.validation_error_header') . "\n" . $errorList;
+    }
 
-        return "{$header}\n{$errorList}";
+    /**
+     * Finds the most appropriate translation for a given eHealth error message.
+     */
+    private function findTranslationForMessage(string $message, ?string $ruleName): string
+    {
+
+        if (str_contains($message, 'speciality') && str_contains($message, ' with active speciality_officio is not allowed for doctor')) {
+            preg_match('/speciality (.+?) with active speciality_officio is not allowed for doctor/', $message, $matches);
+            return trans('errors.ehealth.messages.speciality_officio_not_allowed', ['speciality' => $matches[1] ?? '']);
+        }
+
+        $key = $ruleName ?? $message;
+        if (trans()->has('errors.ehealth.messages.' . $key)) {
+            return trans('errors.ehealth.messages.' . $key);
+        }
+
+        Log::warning("Untranslated eHealth error message found.", [
+            'original_message' => $message,
+            'rule_name' => $ruleName,
+        ]);
+
+        return $message;
     }
 }

--- a/app/Jobs/EmployeeDetailsUpsert.php
+++ b/app/Jobs/EmployeeDetailsUpsert.php
@@ -15,7 +15,7 @@ use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use App\Classes\eHealth\EHealth;
-use Spatie\Permission\PermissionRegistrar;
+use Illuminate\Support\Facades\Log;
 use Throwable;
 
 class EmployeeDetailsUpsert implements ShouldQueue
@@ -62,21 +62,24 @@ class EmployeeDetailsUpsert implements ShouldQueue
 
         $this->employee->refresh();
 
-        $user = $this->employee->user;
+        $user = $this->employee->party->user;
+
+        if (!$user) {
+            Log::info('Employee sync: User does not exist yet for party.', [
+                'party_id' => $this->employee->party_id,
+                'employee_uuid' => $this->employee->uuid,
+            ]);
+
+            return;
+        }
+
         $roleName = $this->employee->employee_type;
         $legalEntityId = $this->employee->legal_entity_id;
 
-        if ($user && $roleName && $legalEntityId) {
-            setPermissionsTeamId($legalEntityId);
+        setPermissionsTeamId($legalEntityId);
 
-            $user->unsetRelation('roles')->unsetRelation('permissions');
-
-            if (!$user->hasRole($roleName)) {
-                $user->assignRole($roleName);
-
-                app(PermissionRegistrar::class)->forgetCachedPermissions();
-            }
-
+        if (!$user->hasRole($roleName)) {
+            $user->assignRole($roleName);
         }
     }
 }

--- a/app/Jobs/EmployeeDetailsUpsert.php
+++ b/app/Jobs/EmployeeDetailsUpsert.php
@@ -73,6 +73,8 @@ class EmployeeDetailsUpsert implements ShouldQueue
 
             if (!$user->hasRole($roleName)) {
                 $user->assignRole($roleName);
+
+                app(PermissionRegistrar::class)->forgetCachedPermissions();
             }
 
         }

--- a/app/Listeners/eHealth/BaseEmployeeListener.php
+++ b/app/Listeners/eHealth/BaseEmployeeListener.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace App\Listeners\eHealth;
 
 use App\Classes\eHealth\EHealth;
+use App\Core\Arr;
 use App\Enums\Employee\RevisionStatus;
 use App\Enums\Status;
 use App\Events\EHealthUserLogin;
+use App\Models\Division;
 use App\Models\Employee\Employee;
 use App\Models\Employee\EmployeeRequest;
 use App\Repositories\Repository;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Spatie\Permission\PermissionRegistrar;
 use Throwable;
 
 abstract class BaseEmployeeListener
@@ -95,6 +96,14 @@ abstract class BaseEmployeeListener
      */
     abstract protected function fetchEmployeesFromApi(EHealthUserLogin $event): array;
 
+    /**
+     * A hook method that can be implemented by child listeners
+     * to perform actions after the employee list has been fetched from eHealth.
+     *
+     * @param EHealthUserLogin $event The event instance.
+     * @param array &$ehealthEmployees The array of employees fetched from eHealth.
+     * @return void
+     */
     protected function afterFetchingEmployees(EHealthUserLogin $event, array &$ehealthEmployees): void
     {
         // By default, do nothing.
@@ -129,20 +138,44 @@ abstract class BaseEmployeeListener
      */
     protected function createEmployeeFromRequest(EmployeeRequest $employeeRequest, array $approvedData): void
     {
-        $mappedData = EHealth::employeeRequest()::mapCreate($employeeRequest, $approvedData);
+        $sourceData = $employeeRequest->revision->data;
 
-        $employeeData = $mappedData['employee'];
-        $partyData = $mappedData['party'];
-        $doctorData = $mappedData['doctor'];
+        $mappedData = EHealth::employeeRequest()->mapCreate($sourceData);
+
+        $employeeData = array_merge(
+            $mappedData['employee'],
+            [
+                'legal_entity_id' => $employeeRequest->legal_entity_id,
+                'legal_entity_uuid' => $employeeRequest->legal_entity_uuid,
+                'party_id' => $employeeRequest->party_id,
+                'user_id' => $employeeRequest->party->user_id,
+                'inserted_at' => now(),
+                'uuid' => $approvedData['uuid'],
+                'status' => $approvedData['status'],
+                'is_active' => $approvedData['is_active'] ?? true,
+            ]
+        );
+
+        $localDivisionId = Arr::get($mappedData, 'employee.division_id');
+        if ($localDivisionId) {
+            $division = Division::find($localDivisionId);
+            $employeeData['division_uuid'] = $division?->uuid;
+        }
+
+        $partyData = array_merge(
+            $mappedData['party'],
+            ['uuid' => Arr::get($approvedData, 'party.uuid')]
+        );
+
         $documentsData = $mappedData['documents'];
         $phonesData = $mappedData['phones'];
+        $doctorData = $mappedData;
 
         DB::transaction(function () use ($employeeData, $partyData, $doctorData, $documentsData, $phonesData, $employeeRequest) {
             $employeeModel = Employee::updateOrCreate(
                 ['uuid' => $employeeData['uuid']],
                 $employeeData
             );
-
             Repository::employee()->updateDetails(
                 $employeeModel,
                 $partyData,
@@ -153,7 +186,6 @@ abstract class BaseEmployeeListener
                 $doctorData['qualifications'] ?? null,
                 $doctorData['science_degree'] ?? null
             );
-
             $this->assignRoleToUser($employeeModel);
             $this->finalizeEmployeeRequest($employeeRequest, $employeeModel);
         });
@@ -174,8 +206,6 @@ abstract class BaseEmployeeListener
 
             if (!$user->hasRole($roleName)) {
                 $user->assignRole($roleName);
-
-                app(PermissionRegistrar::class)->forgetCachedPermissions();
             }
         }
     }

--- a/app/Listeners/eHealth/BaseEmployeeListener.php
+++ b/app/Listeners/eHealth/BaseEmployeeListener.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Listeners\eHealth;
 
-use App\Classes\eHealth\Api\Employee as EmployeeApi;
+use App\Classes\eHealth\EHealth;
 use App\Enums\Employee\RevisionStatus;
 use App\Enums\Status;
 use App\Events\EHealthUserLogin;
@@ -129,8 +129,7 @@ abstract class BaseEmployeeListener
      */
     protected function createEmployeeFromRequest(EmployeeRequest $employeeRequest, array $approvedData): void
     {
-        // NEW: Get all prepared data from the mapper method
-        $mappedData = EmployeeApi::mapCreate($employeeRequest, $approvedData);
+        $mappedData = EHealth::employeeRequest()::mapCreate($employeeRequest, $approvedData);
 
         $employeeData = $mappedData['employee'];
         $partyData = $mappedData['party'];
@@ -152,7 +151,7 @@ abstract class BaseEmployeeListener
                 $doctorData['educations'] ?? null,
                 $doctorData['specialities'] ?? null,
                 $doctorData['qualifications'] ?? null,
-                $doctorData['scienceDegree'] ?? null
+                $doctorData['science_degree'] ?? null
             );
 
             $this->assignRoleToUser($employeeModel);

--- a/app/Listeners/eHealth/BaseEmployeeListener.php
+++ b/app/Listeners/eHealth/BaseEmployeeListener.php
@@ -29,6 +29,7 @@ abstract class BaseEmployeeListener
 
         try {
             $ehealthEmployees = $this->fetchEmployeesFromApi($event);
+            $this->afterFetchingEmployees($event, $ehealthEmployees);
         } catch (Throwable $e) {
             Log::error('Failed to fetch employee list from E-Health.', [
                 'listener' => static::class,
@@ -59,16 +60,18 @@ abstract class BaseEmployeeListener
             return; // Nothing to create
         }
 
+        $newEhealthEmployees = collect($ehealthEmployees)->whereIn('uuid', $newEmployeeUuids);
+
         // Find the corresponding local requests for the new employees
-        $pendingRequests = $this->getPendingRequestsForNewEmployees($event, collect($ehealthEmployees), $newEmployeeUuids);
+        $pendingRequestsPairs = $this->getPendingRequestsForNewEmployees($event, $newEhealthEmployees);
 
-        foreach ($pendingRequests as $employeeRequest) {
+        foreach ($pendingRequestsPairs as $pair) {
+            $employeeRequest = $pair['request'];
+            $approvedData = $pair['api_data'];
+
             try {
-                // Find the full data for this specific new employee from the API response
-                $approvedData = collect($ehealthEmployees)->firstWhere('uuid', $employeeRequest->employee_uuid_from_api);
-
                 if ($approvedData) {
-                    $this->createEmployeeFromRequest($employeeRequest, $approvedData, $event->user);
+                    $this->createEmployeeFromRequest($employeeRequest, $approvedData);
                 }
             } catch (Throwable $e) {
                 Log::error('Failed to process a new employee from request.', [
@@ -91,17 +94,18 @@ abstract class BaseEmployeeListener
      */
     abstract protected function fetchEmployeesFromApi(EHealthUserLogin $event): array;
 
+    protected function afterFetchingEmployees(EHealthUserLogin $event, array &$ehealthEmployees): void
+    {
+        // By default, do nothing.
+    }
+
     /**
      * Find local EmployeeRequest records that match the new employees found in the API response.
      */
-    protected function getPendingRequestsForNewEmployees(EHealthUserLogin $event, Collection $ehealthEmployees, array $newEmployeeUuids): Collection
+    protected function getPendingRequestsForNewEmployees(EHealthUserLogin $event, Collection $newEmployeesFromApi): Collection
     {
-        $newEmployeesFromApi = $ehealthEmployees->whereIn('uuid', $newEmployeeUuids);
-
         $pendingRequests = Repository::employee()->findPendingRequestsForUser($event->user, $event->legalEntity);
 
-        // We need to match local requests to the API response by position and type,
-        // then attach the final employee UUID to the request object for later use.
         return $pendingRequests->map(function (EmployeeRequest $request) use ($newEmployeesFromApi) {
             $apiMatch = $newEmployeesFromApi->firstWhere(function ($apiEmployee) use ($request) {
                 return $apiEmployee['position'] === $request->position
@@ -109,14 +113,11 @@ abstract class BaseEmployeeListener
             });
 
             if ($apiMatch) {
-                // Temporarily attach the final UUID to the request model
-                $request->employee_uuid_from_api = $apiMatch['uuid'];
-
-                return $request;
+                return ['request' => $request, 'api_data' => $apiMatch];
             }
 
             return null;
-        })->filter(); // Remove requests that didn't have a match
+        })->filter();
     }
 
     /**
@@ -126,36 +127,16 @@ abstract class BaseEmployeeListener
      */
     protected function createEmployeeFromRequest(EmployeeRequest $employeeRequest, array $approvedData): void
     {
-        // THE SOURCE OF TRUTH: Data from the revision, which the user signed.
-        $revisionData = $employeeRequest->revision->data;
+        // NEW: Get all prepared data from the mapper method
+        $mappedData = EmployeeApi::mapCreate($employeeRequest, $approvedData);
 
-        // Manually build the employee data array from the correct sources
-        $employeeData = [
-            // Data from the Revision (what user signed)
-            'position' => $revisionData['employee_request_data']['position'],
-            'employee_type' => $revisionData['employee_request_data']['employee_type'],
-            'start_date' => $revisionData['employee_request_data']['start_date'],
-            'end_date' => $revisionData['employee_request_data']['end_date'],
-            'division_id' => $revisionData['employee_request_data']['division_id'],
+        $employeeData = $mappedData['employee'];
+        $partyData = $mappedData['party'];
+        $doctorData = $mappedData['doctor'];
+        $documentsData = $mappedData['documents'];
+        $phonesData = $mappedData['phones'];
 
-            // Data from existing relationships
-            'legal_entity_id' => $employeeRequest->legal_entity_id,
-            'legal_entity_uuid' => $employeeRequest->legal_entity_uuid,
-            'inserted_at' => now(),
-            'party_id' => $employeeRequest->party_id,
-            'user_id' => $employeeRequest->party->user_id,
-
-            // Final, confirmed data from the live E-Health response
-            'uuid' => $approvedData['uuid'],
-            'status' => $approvedData['status'],
-            'is_active' => $approvedData['is_active'] ?? true,
-        ];
-
-        // Party and Doctor data can still be mapped as they operate on correct sub-arrays
-        $partyData = EmployeeApi::mapPartyData($revisionData['party'] ?? []);
-        $doctorData = $revisionData['doctor'] ?? [];
-
-        DB::transaction(function () use ($employeeData, $partyData, $doctorData, $revisionData, $employeeRequest) {
+        DB::transaction(function () use ($employeeData, $partyData, $doctorData, $documentsData, $phonesData, $employeeRequest) {
             $employeeModel = Employee::updateOrCreate(
                 ['uuid' => $employeeData['uuid']],
                 $employeeData
@@ -164,8 +145,8 @@ abstract class BaseEmployeeListener
             Repository::employee()->updateDetails(
                 $employeeModel,
                 $partyData,
-                $revisionData['documents'] ?? [],
-                $revisionData['phones'] ?? [],
+                $documentsData,
+                $phonesData,
                 $doctorData['educations'] ?? null,
                 $doctorData['specialities'] ?? null,
                 $doctorData['qualifications'] ?? null,
@@ -188,7 +169,7 @@ abstract class BaseEmployeeListener
 
         if ($user && $roleName && $legalEntityId) {
             setPermissionsTeamId($legalEntityId);
-            $user->unsetRelation('roles');
+            $user->unsetRelation('roles')->unsetRelation('permissions');
 
             if (!$user->hasRole($roleName)) {
                 $user->assignRole($roleName);

--- a/app/Listeners/eHealth/BaseEmployeeListener.php
+++ b/app/Listeners/eHealth/BaseEmployeeListener.php
@@ -14,6 +14,7 @@ use App\Repositories\Repository;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Spatie\Permission\PermissionRegistrar;
 use Throwable;
 
 abstract class BaseEmployeeListener
@@ -94,24 +95,20 @@ abstract class BaseEmployeeListener
     /**
      * Find local EmployeeRequest records that match the new employees found in the API response.
      */
-    protected function getPendingRequestsForNewEmployees(EHealthUserLogin $event, Collection $ehealthEmployees, array $newEmployeeUuids): Collection
+    protected function getPendingRequestsForNewEmployees(EHealthUserLogin $event, Collection $newEmployeesFromApi): Collection
     {
-        $newEmployeesFromApi = $ehealthEmployees->whereIn('uuid', $newEmployeeUuids);
-
         $pendingRequests = Repository::employee()->findPendingRequestsForUser($event->user, $event->legalEntity);
 
-        // We need to match local requests to the API response by position and type,
-        // then attach the final employee UUID to the request object for later use.
         return $pendingRequests->map(function (EmployeeRequest $request) use ($newEmployeesFromApi) {
             $apiMatch = $newEmployeesFromApi->firstWhere(function ($apiEmployee) use ($request) {
                 return $apiEmployee['position'] === $request->position
-                    && $apiEmployee['employee_type'] === $request->employee_type;
+                    && $apiEmployee['employee_type'] === $request->employee_type
+                    && $apiEmployee['start_date'] === $request->start_date?->format('Y-m-d');
             });
 
             if ($apiMatch) {
-                // Temporarily attach the final UUID to the request model
-                $request->employee_uuid_from_api = $apiMatch['uuid'];
 
+                $request->api_data = $apiMatch;
                 return $request;
             }
 
@@ -192,6 +189,8 @@ abstract class BaseEmployeeListener
 
             if (!$user->hasRole($roleName)) {
                 $user->assignRole($roleName);
+
+                app(PermissionRegistrar::class)->forgetCachedPermissions();
             }
         }
     }

--- a/app/Listeners/eHealth/ProcessExistingEmployeeRequests.php
+++ b/app/Listeners/eHealth/ProcessExistingEmployeeRequests.php
@@ -7,6 +7,7 @@ namespace App\Listeners\eHealth;
 use App\Classes\eHealth\EHealth;
 use App\Enums\Status;
 use App\Events\EHealthUserLogin;
+use Illuminate\Http\Client\ConnectionException;
 
 class ProcessExistingEmployeeRequests extends BaseEmployeeListener
 {
@@ -20,6 +21,8 @@ class ProcessExistingEmployeeRequests extends BaseEmployeeListener
 
     /**
      * Fetches employee data using the party's UUID.
+     *
+     * @throws ConnectionException
      */
     protected function fetchEmployeesFromApi(EHealthUserLogin $event): array
     {

--- a/app/Listeners/eHealth/ProcessNewEmployeeRequests.php
+++ b/app/Listeners/eHealth/ProcessNewEmployeeRequests.php
@@ -65,6 +65,15 @@ class ProcessNewEmployeeRequests extends BaseEmployeeListener
         return $response->validate();
     }
 
+    /**
+     * After fetching employees, this method tries to find a "verified" party
+     * from the eHealth response and updates the local user's party with the official UUID.
+     * This is crucial for linking a newly registered user with their official eHealth profile.
+     *
+     * @param EHealthUserLogin $event The event instance.
+     * @param array &$ehealthEmployees The array of employees fetched from eHealth.
+     * @return void
+     */
     protected function afterFetchingEmployees(EHealthUserLogin $event, array &$ehealthEmployees): void
     {
         if (empty($ehealthEmployees)) {

--- a/app/Listeners/eHealth/ProcessNewEmployeeRequests.php
+++ b/app/Listeners/eHealth/ProcessNewEmployeeRequests.php
@@ -62,7 +62,27 @@ class ProcessNewEmployeeRequests extends BaseEmployeeListener
             }
         }
 
-        // Now, return the full, validated response for the main logic to process.
         return $response->validate();
+    }
+
+    protected function afterFetchingEmployees(EHealthUserLogin $event, array &$ehealthEmployees): void
+    {
+        if (empty($ehealthEmployees)) {
+            return;
+        }
+
+        $verifiedPartyData = null;
+        foreach ($ehealthEmployees as $employee) {
+            if (($employee['party']['verification_status'] ?? null) === 'VERIFIED') {
+                $verifiedPartyData = $employee['party'];
+                break;
+            }
+        }
+
+        $partyDataToUse = $verifiedPartyData ?? ($ehealthEmployees[0]['party'] ?? null);
+
+        if ($partyDataToUse && isset($partyDataToUse['uuid'])) {
+            $event->user->party->update(['uuid' => $partyDataToUse['uuid']]);
+        }
     }
 }

--- a/app/Livewire/Employee/EmployeeIndex.php
+++ b/app/Livewire/Employee/EmployeeIndex.php
@@ -24,7 +24,10 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
 use Livewire\Attributes\Computed;
 use Livewire\WithPagination;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Spatie\Permission\PermissionRegistrar;
+use Throwable;
 
 #[AllowDynamicProperties]
 class EmployeeIndex extends EmployeeComponent
@@ -225,6 +228,7 @@ class EmployeeIndex extends EmployeeComponent
         $employee = Employee::find($this->employeeToDeactivateId);
         if (!$employee) {
             $this->closeModal();
+
             return;
         }
 
@@ -234,7 +238,7 @@ class EmployeeIndex extends EmployeeComponent
             if (!empty($response)) {
                 $employee->update(
                     [
-                        'status'   => Status::DISMISSED->value,
+                        'status' => Status::DISMISSED->value,
                         'end_date' => Carbon::now()->format('Y-m-d'),
                     ]
                 );
@@ -244,10 +248,8 @@ class EmployeeIndex extends EmployeeComponent
                     if ($user->hasRole($roleToRemove)) {
                         $user->removeRole($roleToRemove);
 
-                        app(PermissionRegistrar::class)->forgetCachedPermissions();
                     }
                 }
-                // !!! КІНЕЦЬ ПОКРАЩЕННЯ !!!
 
                 $this->dispatch('flashMessage', ['message' => __('employees.dismissalSuccess'), 'type' => 'success']);
             } else {
@@ -260,6 +262,11 @@ class EmployeeIndex extends EmployeeComponent
         $this->closeModal();
     }
 
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws Throwable
+     * @throws NotFoundExceptionInterface
+     */
     public function sync(): void
     {
         try {
@@ -298,6 +305,13 @@ class EmployeeIndex extends EmployeeComponent
                 session()->get(config('ehealth.api.oauth.bearer_token'))
             ))
         )->then(function (Batch $batch) use ($user) {
+
+            app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+            Log::info('Employee sync batch completed successfully. Spatie permissions cache cleared.', [
+                'batch_id' => $batch->id,
+            ]);
+
             $message = __('employees.sync.completed_successfully', [
                 'processed' => $batch->processedJobs,
                 'total' => $batch->totalJobs,

--- a/app/Livewire/Employee/EmployeeIndex.php
+++ b/app/Livewire/Employee/EmployeeIndex.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
 use Livewire\Attributes\Computed;
 use Livewire\WithPagination;
+use Spatie\Permission\PermissionRegistrar;
 
 #[AllowDynamicProperties]
 class EmployeeIndex extends EmployeeComponent
@@ -224,7 +225,6 @@ class EmployeeIndex extends EmployeeComponent
         $employee = Employee::find($this->employeeToDeactivateId);
         if (!$employee) {
             $this->closeModal();
-
             return;
         }
 
@@ -234,10 +234,21 @@ class EmployeeIndex extends EmployeeComponent
             if (!empty($response)) {
                 $employee->update(
                     [
-                        'status' => Status::DISMISSED->value,
+                        'status'   => Status::DISMISSED->value,
                         'end_date' => Carbon::now()->format('Y-m-d'),
                     ]
                 );
+
+                if ($user = $employee->user) {
+                    $roleToRemove = $employee->employee_type;
+                    if ($user->hasRole($roleToRemove)) {
+                        $user->removeRole($roleToRemove);
+
+                        app(PermissionRegistrar::class)->forgetCachedPermissions();
+                    }
+                }
+                // !!! КІНЕЦЬ ПОКРАЩЕННЯ !!!
+
                 $this->dispatch('flashMessage', ['message' => __('employees.dismissalSuccess'), 'type' => 'success']);
             } else {
                 $this->dispatch('flashMessage', ['message' => __('employees.dismissalEhealthError'), 'type' => 'error']);

--- a/app/Livewire/Employee/Forms/EmployeeForm.php
+++ b/app/Livewire/Employee/Forms/EmployeeForm.php
@@ -196,9 +196,9 @@ class EmployeeForm extends Form
             'doctor.scienceDegree.issuedDate' => ['nullable', 'date'],
 
             'doctor.qualifications' => $qualificationsRules,
-            'doctor.qualifications.*.type' => ['required', 'string', 'max:255'], // Словник
+            'doctor.qualifications.*.type' => ['required', 'string', 'max:255'],
             'doctor.qualifications.*.institutionName' => ['required', 'string', 'max:255', new Cyrillic()],
-            'doctor.qualifications.*.speciality' => ['required', 'string', 'max:255'], // Словник
+            'doctor.qualifications.*.speciality' => ['required', 'string', 'max:255'],
             'doctor.qualifications.*.issuedDate' => ['required', 'date'],
             'doctor.qualifications.*.certificateNumber' => ['required', 'string', 'max:255'],
             'doctor.qualifications.*.validTo' => ['nullable', 'date', 'after_or_equal:doctor.qualifications.*.issuedDate'],

--- a/app/Livewire/Employee/Traits/ManagesEmployeeForm.php
+++ b/app/Livewire/Employee/Traits/ManagesEmployeeForm.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\Livewire\Employee\Traits;
 
-use App\Classes\eHealth\Api\Employee as EmployeeApi;
 use App\Classes\eHealth\Api\EmployeeRequest as EHealthEmployeeRequest;
 use App\Core\Arr;
 use App\Enums\Employee\RequestStatus;
 use App\Enums\Employee\RevisionStatus;
 use App\Exceptions\EHealth\EHealthResponseException;
 use App\Exceptions\EHealth\EHealthValidationException;
+use App\Models\Division;
 use App\Models\Employee\BaseEmployee;
 use App\Models\Employee\EmployeeRequest;
 use App\Models\Relations\Party;
@@ -139,7 +139,7 @@ trait ManagesEmployeeForm
         $this->employeeRequest->fill($requestAttributes)->save();
 
         // Step 3: Update the revision to reflect the latest state.
-        $nestedDataForRevision = EmployeeApi::mapRevisionData($preparedDataForDb);
+        $nestedDataForRevision = $this->mapRevisionData($preparedDataForDb);
         if ($this->employeeRequest->revision) {
             $this->employeeRequest->revision->update(['data' => $nestedDataForRevision]);
         } else {
@@ -182,7 +182,7 @@ trait ManagesEmployeeForm
             legalEntity()
         );
 
-        $nestedDataForRevision = EmployeeApi::mapRevisionData($preparedDataForDb);
+        $nestedDataForRevision = $this->mapRevisionData($preparedDataForDb);
         $this->saveRevisionForRequest($newRequest, $nestedDataForRevision);
 
         $this->employeeRequest = $newRequest;
@@ -439,64 +439,76 @@ trait ManagesEmployeeForm
     }
 
     /**
-     * Prepares the nested data from a Revision for the eHealth API payload.
-     *
-     * @param array $nestedData The data from the Revision model.
-     * @return array The payload ready for the eHealth API.
+     * Prepares the nested data structure for a Revision from flat form data.
      */
+    private function mapRevisionData(array $flatData): array
+    {
+        $employeeChunk = Arr::only($flatData, ['position', 'employee_type', 'start_date', 'end_date', 'division_id']);
+        $partyChunk = Arr::only($flatData, ['last_name', 'first_name', 'second_name', 'gender', 'birth_date', 'tax_id', 'no_tax_id', 'email', 'working_experience', 'about_myself']);
+        $documentsChunk = $flatData['documents'] ?? [];
+        $phonesChunk = $flatData['phones'] ?? [];
+        $doctorChunk = $flatData['doctor'] ?? [];
+
+        return [
+            'employee_request_data' => $employeeChunk,
+            'party' => $partyChunk,
+            'documents' => $documentsChunk,
+            'phones' => $phonesChunk,
+            'doctor' => $doctorChunk,
+        ];
+    }
+
     private function preparePayloadForEHealth(array $nestedData): array
     {
+        $localDivisionId = Arr::get($nestedData, 'employee_request_data.division_id');
+        $divisionUuid = $localDivisionId ? Division::find($localDivisionId)?->uuid : null;
+
+        $partyPayload = Arr::only($nestedData['party'] ?? [], [
+            'first_name', 'last_name', 'second_name', 'birth_date', 'gender',
+            'tax_id', 'email', 'about_myself'
+        ]);
+
+        $partyPayload['no_tax_id'] = (bool) Arr::get($nestedData, 'party.no_tax_id');
+        $partyPayload['working_experience'] = (int) Arr::get($nestedData, 'party.working_experience');
+        $partyPayload['documents'] = $nestedData['documents'] ?? [];
+        $partyPayload['phones'] = $nestedData['phones'] ?? [];
+
         $payload = [
             'position' => Arr::get($nestedData, 'employee_request_data.position'),
             'start_date' => Arr::get($nestedData, 'employee_request_data.start_date'),
             'end_date' => Arr::get($nestedData, 'employee_request_data.end_date'),
             'employee_type' => Arr::get($nestedData, 'employee_request_data.employee_type'),
-            'division_id' => Arr::get($nestedData, 'employee_request_data.division_id'),
-            'legal_entity_id' => Arr::get($nestedData, 'employee_request_data.legal_entity_id'),
+            'division_id' => $divisionUuid,
+            'legal_entity_id' => legalEntity()->uuid,
             'status' => 'NEW',
-            'party' => [
-                'first_name' => Arr::get($nestedData, 'party.first_name'),
-                'last_name' => Arr::get($nestedData, 'party.last_name'),
-                'second_name' => Arr::get($nestedData, 'party.second_name'),
-                'birth_date' => Arr::get($nestedData, 'party.birth_date'),
-                'gender' => Arr::get($nestedData, 'party.gender'),
-                'no_tax_id' => (bool) Arr::get($nestedData, 'party.no_tax_id'),
-                'tax_id' => Arr::get($nestedData, 'party.tax_id'),
-                'email' => Arr::get($nestedData, 'party.email'),
-                'documents' => Arr::get($nestedData, 'documents'),
-                'phones' => Arr::get($nestedData, 'phones'),
-                'working_experience' => (int) Arr::get($nestedData, 'party.working_experience'),
-                'about_myself' => Arr::get($nestedData, 'party.about_myself'),
-            ],
+            'party' => $partyPayload,
         ];
 
         $doctorTypes = config('ehealth.doctors_type', []);
         $employeeType = Arr::get($nestedData, 'employee_request_data.employee_type');
 
-
         if (in_array($employeeType, $doctorTypes, true)) {
-            $doctorData = [
-                'educations' => Arr::get($nestedData, 'doctor.educations'),
-                'qualifications' => Arr::get($nestedData, 'doctor.qualifications'),
-                'specialities' => Arr::get($nestedData, 'doctor.specialities'),
-                'science_degree' => Arr::get($nestedData, 'doctor.science_degree'),
-            ];
-
-            $payloadKey = strtolower($employeeType);
-            $payload[$payloadKey] = $doctorData;
+            $doctorData = Arr::get($nestedData, 'doctor');
+            if (!empty($doctorData)) {
+                $payloadKey = strtolower($employeeType);
+                $payload[$payloadKey] = $doctorData;
+            }
         }
 
-        // Clean up empty fields
-        $payload = array_filter($payload, fn($value) => !is_null($value) && $value !== '');
-        if (isset($payload['party'])) {
-            $payload['party'] = array_filter($payload['party'], fn ($value) => !is_null($value) && $value !== '');
+        return ['employee_request' => $this->array_filter_recursive($payload)];
+    }
+
+    private function array_filter_recursive(array $array): array
+    {
+        foreach ($array as $key => &$value) {
+            if (is_array($value)) {
+                $value = $this->array_filter_recursive($value);
+            }
         }
 
-        if (isset($payloadKey, $payload[$payloadKey])) {
-            $payload[$payloadKey] = array_filter($payload[$payloadKey], fn ($value) => !is_null($value) && $value !== '' && !empty($value));
-        }
-
-        return ['employee_request' => $payload];
+        return array_filter($array, function ($value) {
+            return !is_null($value) && $value !== '' && $value !== [];
+        });
     }
 
     /**

--- a/app/Repositories/EmployeeRepository.php
+++ b/app/Repositories/EmployeeRepository.php
@@ -263,6 +263,7 @@ readonly class EmployeeRepository
                 );
 
                 $model->party()->update($result);
+
             }
         }
     }


### PR DESCRIPTION
Додай оновлення доступів, після звільнення і пододава app(PermissionRegistrar::class)->forgetCachedPermissions();
у лісенер і джаб.
Бо https://spatie.be/docs/laravel-permission/v6/advanced-usage/cache#content-manual-cache-reset
Виклик app(PermissionRegistrar::class)->forgetCachedPermissions(); є єдиним правильним способом сказати всій програмі: "Увага, дані про права доступу змінилися, будь ласка, завантажте їх наново з бази даних при наступному запиті".

Повернув жосткі правила на документи issued_at/by
Максимальна підготовка до фіналізації модуля співробітника.


Переробив експепшн валідації, бо то було тимчасове рішення з перекладами.

Ті кейси шо я вписав у файли перекладів. Залишаться а як не знайде буде англійською показувати.