### PR TITLE
i285_add_roles_on_verify_personality_update_ehealth_roles

### DIFF
--- a/app/Classes/eHealth/Api/EmployeeRequest.php
+++ b/app/Classes/eHealth/Api/EmployeeRequest.php
@@ -37,6 +37,16 @@ class EmployeeRequest extends EHealthRequest
         ];
     }
 
+    /**
+     * Transforms a source data array into a structured, partitioned array.
+     *
+     * This method takes a source array, typically from a Revision's data,
+     * and reshapes it into a consistent structure with keys like 'employee',
+     * 'party', 'documents', etc., making it ready for repository processing.
+     *
+     * @param array $sourceData The source data array containing all necessary information.
+     * @return array A structured array partitioned into logical keys.
+     */
     public function mapCreate(array $sourceData): array
     {
 

--- a/app/Events/EhealthUserVerified.php
+++ b/app/Events/EhealthUserVerified.php
@@ -8,7 +8,7 @@ use App\Models\User;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class UserVerifiedAndLinked
+class EhealthUserVerified
 {
     use Dispatchable;
     use SerializesModels;

--- a/app/Events/UserVerifiedAndLinked.php
+++ b/app/Events/UserVerifiedAndLinked.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\User;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class UserVerifiedAndLinked
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public User $user;
+    public int $legalEntityId;
+
+    public function __construct(User $user, int $legalEntityId)
+    {
+        $this->user = $user;
+        $this->legalEntityId = $legalEntityId;
+    }
+}

--- a/app/Listeners/SyncUserRolesAfterVerification.php
+++ b/app/Listeners/SyncUserRolesAfterVerification.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\UserVerifiedAndLinked;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+class SyncUserRolesAfterVerification
+{
+    /**
+     * Synchronizes a user's roles based on their employee positions after
+     * their identity has been successfully verified and linked to a Party.
+     *
+     * This listener is triggered by the UserVerifiedAndLinked event, ensuring that
+     * the user receives the complete and correct set of roles corresponding to all
+     * their official positions within a specific legal entity.
+     */
+    public function handle(UserVerifiedAndLinked $event): void
+    {
+        $user = $event->user;
+        $legalEntityId = $event->legalEntityId;
+
+        setPermissionsTeamId($legalEntityId);
+
+        $roleNames = $user->employees()
+            ->where('legal_entity_id', $legalEntityId)
+            ->pluck('employee_type')
+            ->unique()
+            ->toArray();
+
+        if (empty($roleNames)) {
+            $user->syncRoles([]);
+
+            return;
+        }
+
+        $allRoles = Role::whereIn('name', $roleNames)->get();
+
+        if ($allRoles->isEmpty()) {
+            return;
+        }
+
+        $user->syncRoles($allRoles);
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+}

--- a/app/Listeners/SyncUserRolesAfterVerification.php
+++ b/app/Listeners/SyncUserRolesAfterVerification.php
@@ -24,6 +24,7 @@ class SyncUserRolesAfterVerification
         $legalEntityId = $event->legalEntityId;
 
         setPermissionsTeamId($legalEntityId);
+        $user->unsetRelation('roles');
 
         $roleNames = $user->employees()
             ->where('legal_entity_id', $legalEntityId)
@@ -45,7 +46,5 @@ class SyncUserRolesAfterVerification
         }
 
         $user->syncRoles($allRoles);
-
-        app(PermissionRegistrar::class)->forgetCachedPermissions();
     }
 }

--- a/app/Listeners/SyncUserRolesAfterVerification.php
+++ b/app/Listeners/SyncUserRolesAfterVerification.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Listeners;
 
-use App\Events\UserVerifiedAndLinked;
+use App\Events\EhealthUserVerified;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\PermissionRegistrar;
 
@@ -18,7 +18,7 @@ class SyncUserRolesAfterVerification
      * the user receives the complete and correct set of roles corresponding to all
      * their official positions within a specific legal entity.
      */
-    public function handle(UserVerifiedAndLinked $event): void
+    public function handle(EhealthUserVerified $event): void
     {
         $user = $event->user;
         $legalEntityId = $event->legalEntityId;
@@ -27,6 +27,7 @@ class SyncUserRolesAfterVerification
 
         $roleNames = $user->employees()
             ->where('legal_entity_id', $legalEntityId)
+            ->where('status', 'APPROVED')
             ->pluck('employee_type')
             ->unique()
             ->toArray();

--- a/app/Listeners/eHealth/ProcessNewEmployeeRequests.php
+++ b/app/Listeners/eHealth/ProcessNewEmployeeRequests.php
@@ -7,6 +7,7 @@ namespace App\Listeners\eHealth;
 use App\Classes\eHealth\EHealth;
 use App\Enums\Status;
 use App\Events\EHealthUserLogin;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Log;
 
 class ProcessNewEmployeeRequests extends BaseEmployeeListener
@@ -23,6 +24,8 @@ class ProcessNewEmployeeRequests extends BaseEmployeeListener
     /**
      * Fetches employee data using the party's Tax ID and updates the party with the retrieved UUID,
      * prioritizing the party that is marked as 'VERIFIED' in the E-Health response.
+     *
+     * @throws ConnectionException
      */
     protected function fetchEmployeesFromApi(EHealthUserLogin $event): array
     {

--- a/app/Livewire/Auth/VerifyPersonality.php
+++ b/app/Livewire/Auth/VerifyPersonality.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Auth;
 
 use App\Classes\Cipher\Api\CipherRequest;
 use App\Classes\Cipher\Exceptions\CipherApiException;
+use App\Events\UserVerifiedAndLinked;
 use App\Models\LegalEntity;
 use App\Models\Relations\Party;
 use Illuminate\Http\Client\ConnectionException;
@@ -78,6 +79,8 @@ class VerifyPersonality extends Component
 
         $legalEntityUuid = Session::pull('selected_legal_entity_uuid');
         $legalEntity = LegalEntity::whereUuid($legalEntityUuid)->firstOrFail();
+
+        UserVerifiedAndLinked::dispatch(Auth::user(), $legalEntity->id);
 
         $this->redirectRoute('dashboard', ['legalEntity' => $legalEntity], navigate: true);
     }

--- a/app/Livewire/Auth/VerifyPersonality.php
+++ b/app/Livewire/Auth/VerifyPersonality.php
@@ -6,7 +6,7 @@ namespace App\Livewire\Auth;
 
 use App\Classes\Cipher\Api\CipherRequest;
 use App\Classes\Cipher\Exceptions\CipherApiException;
-use App\Events\UserVerifiedAndLinked;
+use App\Events\EhealthUserVerified;
 use App\Models\LegalEntity;
 use App\Models\Relations\Party;
 use Illuminate\Http\Client\ConnectionException;
@@ -80,7 +80,7 @@ class VerifyPersonality extends Component
         $legalEntityUuid = Session::pull('selected_legal_entity_uuid');
         $legalEntity = LegalEntity::whereUuid($legalEntityUuid)->firstOrFail();
 
-        UserVerifiedAndLinked::dispatch(Auth::user(), $legalEntity->id);
+        EhealthUserVerified::dispatch(Auth::user(), $legalEntity->id);
 
         $this->redirectRoute('dashboard', ['legalEntity' => $legalEntity], navigate: true);
     }


### PR DESCRIPTION
Ось сухий аналіз ключових відмінностей:

ASSISTANT (Асистент)
Що видалено: Велика кількість прав, що не стосуються прямих обов'язків асистента, а також застарілі/конфліктні права.

Ключові видалення: preperson:*, merge_request:*, authentication_method_request:write, person_verification:*.

Причина: Це головні "токсичні" права, які викликали помилки при вході. Документація фокусується на сучасних аналогах (person_request:*, person:verify), що підтверджує, що це застарілий функціонал.

Також видалено: employee_request:*, medication_request:*, device_request:*.

Причина: Це права на адміністративні (employee_request) або клінічні (medication_request) рішення. Роль асистента була перефокусована на виконання завдань (запис даних, читання інформації), а не на прийняття рішень, що робить роль безпечнішою для комбінування.

LABORANT (Лаборант)
Що видалено: Права, що не стосуються лабораторної роботи.

Ключові видалення: employee_request:approve, employee_request:reject, service_request:use, service_request:makeinprogress.

Причина: Згідно з логікою, лаборант працює з діагностичними звітами (diagnostic_report) та спостереженнями (observation). Затвердження запитів на працевлаштування (employee_request) — це функція HR або адміністратора. Застарілі статуси запитів на послуги (makeinprogress) були спрощені до стандартних read та complete, як це зазначено в сучасних API.

RECEPTIONIST (Реєстратор)
Що видалено: Застарілі права та права, що не відповідають ролі.

Ключові видалення: preperson:*, merge_request:*, authentication_method_request:write, person_verification:*.

Причина: Та сама, що й для асистента — ці права викликали конфлікти і є застарілими.

Також видалено: capitation_report:read, approval:create та права на запис клінічних даних (observation:write, allergy_intolerance:write).

Причина: Доступ до фінансових звітів (capitation_report) та можливість записувати медичні дані не є функцією реєстратора. Нова роль сфокусована на роботі з деклараціями, пацієнтами на рівні реєстрації (person, otp) та записами на прийом.

MED_ADMIN (Медичний адміністратор)
Що видалено: Усі права на активні дії та застарілі права.

Ключові видалення: preperson:read, medication_request:reject, medication_request_request:*, device_request:revoke.

Причина: Роль була переосмислена як аудиторська або контролююча з доступом тільки на читання (read-only). Це робить її абсолютно безпечною для додавання до будь-якого користувача, оскільки вона не може створювати логічних конфліктів ("і створювати, і відхиляти запит"). Вона дозволяє бачити майже все, але нічого не змінювати.

MED_COORDINATOR (Медичний координатор)
Що видалено: Застарілі та конфліктні права.

Ключові видалення: preperson:read, merge_request:write, medication_request_request:*, person_verification:*.

Причина: Роль була очищена від того ж "сміття", що й інші. Основний функціонал (робота з service_request, care_plan, encounter) був збережений, але без застарілих механізмів управління пацієнтами.

Подія #1: EHealthUserLogin

Коли спрацьовує: Відразу після початкового входу через ЕСОЗ.

Що робить: Запускає слухачів ProcessNewEmployeeRequests та ProcessExistingEmployeeRequests. Їхній порядок між собою неважливий, оскільки вони працюють з різними даними.

Подія #2: UserVerifiedAndLinked

Коли спрацьовує: Тільки після того, як користувач успішно верифікував себе за допомогою КЕП у компоненті VerifyPersonality.

Що робить: Запускає єдиного слухача SyncUserRolesAfterVerification, який призначає користувачу фінальний набір ролей.

Таким чином, слухач для призначення ролей (SyncUserRolesAfterVerification) гарантовано спрацює лише після того, як відпрацює вся логіка початкового входу та верифікації. 

