### PR TITLE
#457_fix_for_employee_listeners

### DIFF
--- a/app/Http/Controllers/Auth/EHealthLoginController.php
+++ b/app/Http/Controllers/Auth/EHealthLoginController.php
@@ -123,10 +123,17 @@ class EHealthLoginController extends Controller
             trim(data_get($validatedEHealthTokenData, 'details.scope'))
         );
 
+        if (empty($user->party)) {
+            $this->isPartiallyVerified = true;
+        }
+
         if ($this->isPartiallyVerified) {
             Session::put('selected_legal_entity_uuid', $legalEntity->uuid);
-            // Respect EHealth scopes
-            $user->syncPermissions($ehealthScopes);
+
+            if ($roleName = Session::pull('first_login_role')) {
+                setPermissionsTeamId($legalEntity->id);
+                $user->assignRole($roleName);
+            }
 
             return Redirect::route('party.verify');
         }

--- a/app/Listeners/eHealth/ProcessExistingEmployeeRequests.php
+++ b/app/Listeners/eHealth/ProcessExistingEmployeeRequests.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Listeners\eHealth;
 
 use App\Classes\eHealth\EHealth;
+use App\Enums\Employee\RequestStatus;
 use App\Enums\Status;
 use App\Events\EHealthUserLogin;
 use Illuminate\Http\Client\ConnectionException;
@@ -12,11 +13,19 @@ use Illuminate\Http\Client\ConnectionException;
 class ProcessExistingEmployeeRequests extends BaseEmployeeListener
 {
     /**
-     * This listener should only process if the user's party is already synced with E-Health (has a UUID).
+     * This listener should only process if the user's party is synced
+     * AND if there are any actual employee requests in a syncable status.
      */
     protected function shouldProcess(EHealthUserLogin $event): bool
     {
-        return isset($event->user->party->uuid);
+        if (!isset($event->user->party->uuid)) {
+            return false;
+        }
+
+        return $event->user->employeeRequests()
+            ->whereIn('status', RequestStatus::getStatusesForSync())
+            ->exists();
+
     }
 
     /**


### PR DESCRIPTION
по пунктам 
Сторінка, яка підтверджує особу кепом має або після лістенера, який створює нових співробітників або має бути додаткова перевірка на наявність імейла в паті при кожному логіні - див isPartiallyVerified
і
Лістенер ProcessExistingEmployee спрацьовує навіть тоді, коли користувач не має нових employee requests