### PR TITLE
#470: division buttons bugfixes

### DIFF
--- a/app/Livewire/Division/Trait/HasAction.php
+++ b/app/Livewire/Division/Trait/HasAction.php
@@ -54,6 +54,15 @@ trait HasAction
 
         try {
             Repository::division()->setAction($division, $responseData['status']);
+
+            // Refresh model and sync local state
+            $division->refresh();
+
+            // Keep a fresh instance on the component if it uses it
+            $this->divisionForm->division['status'] = $responseData['status'];
+
+            // Trigger a lightweight re-render
+            $this->dispatch('$refresh');
         } catch (Exception $err) {
             Log::channel('db_errors')->error(static::class . ':activateDivision:', ['message' => $err->getMessage()]);
 
@@ -100,6 +109,15 @@ trait HasAction
 
         try {
             Repository::division()->setAction($division, $responseData['status']);
+
+            // Refresh model and sync local state
+            $division->refresh();
+
+            // Keep a fresh instance on the component if it uses it
+            $this->divisionForm->division['status'] = $responseData['status'];
+
+            // Trigger a lightweight re-render
+            $this->dispatch('$refresh');
         } catch (Exception $err) {
             Log::channel('db_errors')->error(static::class . ':deactivateDivision:', ['message' => $err->getMessage()]);
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -393,6 +393,14 @@ input:-webkit-autofill ~ .label {
     @apply flex items-center justify-between cursor-pointer w-full p-5 font-medium rtl:text-right text-gray-500 border border-gray-200 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-800 dark:border-gray-700 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 gap-3;
 }
 
+/* Ensure Back + additional buttons align perfectly */
+.additional-actions > a,
+.additional-actions > button,
+.additional-actions > * > a,
+.additional-actions > * > button {
+    @apply inline-flex items-center leading-none !mb-0;
+}
+
 /* Tables */
 .table-section {
     @apply bg-gray-100 dark:bg-gray-900 p-3 sm:p-5;

--- a/resources/views/livewire/division/division-create.blade.php
+++ b/resources/views/livewire/division/division-create.blade.php
@@ -10,11 +10,11 @@
 @endsection
 
 @section('additional-buttons')
-    <div>
+    <div class="flex items-center gap-2 self-center">
     <button
             type="button"
             id="save_button"
-            class="button-primary-outline"
+            class="button-primary-outline !mb-0 leading-none inline-flex items-center"
             wire:click="store"
         >
             {{ __('forms.save') }}
@@ -23,7 +23,7 @@
         <button
             type="button"
             id="save_button"
-            class="button-primary cursor-pointer"
+            class="button-primary cursor-pointer !mb-0 leading-none inline-flex items-center"
             wire:click="create"
         >
             {{ __('forms.save_and_send') }}

--- a/resources/views/livewire/division/division-edit.blade.php
+++ b/resources/views/livewire/division/division-edit.blade.php
@@ -16,11 +16,11 @@
 @endsection
 
 @section('additional-buttons')
-    <div class="mb-[10px] flex flex-col gap-6 xl:flex-row justify-start items-center w-full">
+    <div class="flex items-center gap-2">
         <button
             type="button"
             id="save_button"
-            class="button-primary cursor-pointer"
+            class="button-primary cursor-pointer inline-flex items-center leading-none mb-0"
             wire:click="store"
         >
             {{ __('forms.save') }}
@@ -35,7 +35,7 @@
                     actionTitle=@js(__('divisions.modals.delete.title'));
                     actionButtonText=@js(__('forms.delete'));
                 "
-                class="alternative-button cursor-pointer mt-2"
+                class="alternative-button cursor-pointer inline-flex items-center leading-none mb-0"
             >
                 {{ __('forms.delete') }}
             </button>
@@ -44,7 +44,7 @@
         <button
             type="button"
             id="save_button"
-            class="button-primary cursor-pointer"
+            class="button-primary cursor-pointer inline-flex items-center leading-none mb-0"
             wire:click="update"
         >
             {{ __('forms.save_and_send') }}

--- a/resources/views/livewire/division/division-index.blade.php
+++ b/resources/views/livewire/division/division-index.blade.php
@@ -76,7 +76,10 @@
 
                 <tbody>
                 @forelse ($divisions as $division)
-                    <tr x-data="{ divisionTypes: $wire.entangle('dictionaries.DIVISION_TYPE') }" class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 border-gray-200">
+                    <tr
+                        wire:key = '{{ $division->id }}'
+                        x-data="{ divisionTypes: $wire.entangle('dictionaries.DIVISION_TYPE') }"
+                        class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 border-gray-200">
                         <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white break-words whitespace-normal align-top">
                             <p>{{ $division->name ?? '' }}</p>
                         </th>
@@ -89,6 +92,7 @@
                         <td class="px-6 py-4 break-words whitespace-normal align-top">
                             <p>{{ $division->email ?? '' }}</p>
                         </td>
+
                         <td class="px-6 py-4 break-words whitespace-normal align-top">
                             @if ($division->status === Status::INACTIVE)
                                 <span class="badge-red">{{ __('forms.status.non_active') }}</span>
@@ -132,6 +136,7 @@
                                             type="button"
                                             class="hover:text-primary cursor-pointer"
                                             outline="none"
+                                            id="menu-{{ $division->id }}"
                                     >
                                         <svg class="svg-hover-action w-6 h-6 text-gray-800 dark:text-white"
                                              aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18"
@@ -141,13 +146,16 @@
                                                   d="M7 19H5a1 1 0 0 1-1-1v-1a3 3 0 0 1 3-3h1m4-6a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm7.441 1.559a1.907 1.907 0 0 1 0 2.698l-6.069 6.069L10 19l.674-3.372 6.07-6.07a1.907 1.907 0 0 1 2.697 0Z"/>
                                         </svg>
                                     </button>
-                                    <div x-show="open"
-                                         x-cloak
-                                         x-ref="panel"
-                                         x-transition.origin.top.left
-                                         @click.outside="close($refs.button)"
-                                         :id="$id('dropdown-button')"
-                                         class="absolute right-0 mt-2 w-40 rounded-md bg-white shadow-md z-50"
+
+                                    <div
+                                        x-show="open"
+                                        x-cloak
+                                        x-ref="panel"
+                                        x-transition.origin.top.left
+                                        @click.outside="close($refs.button)"
+                                        :id="$id('dropdown-button')"
+                                        class="absolute right-0 mt-2 w-40 rounded-md bg-white shadow-md z-50"
+                                        wire:key="menu-{{ $division->id }}-{{ is_string($division->status) ? $division->status : ($division->status?->value ?? 'unknown') }}"
                                     >
                                         @can('create', HealthcareService::class)
                                             <a href="{{ route('healthcare-service.index', [legalEntity(), $division]) }}"
@@ -174,25 +182,9 @@
                                             </a>
                                         @endcan
 
-                                        @can('deactivate', $division)
-                                            <a href="#"
-                                               @click.prevent="
-                                                   divisionId= {{ $division->id }};
-                                                   textConfirmation = @js(__('divisions.modals.deactivate.confirmation_text'));
-                                                   actionType = 'deactivate';
-                                                   actionTitle = @js(__('divisions.modals.deactivate.title'));
-                                                   actionButtonText = @js(__('forms.deactivate'));
-                                                   open = !open;
-                                               "
-                                               class="flex items-center gap-2 w-full last-of-type:rounded-b-md px-4 py-2.5 text-left text-sm text-red-600 hover:bg-red-50"
-                                            >
-                                                @icon('delete', 'w-5 h-5 text-red-600')
-                                                {{ __('forms.deactivate') }}
-                                            </a>
-                                        @endcan
-
                                         @can('activate', $division)
                                             <a href="#"
+                                               wire:key="activate-{{ $division->id }}"
                                                @click.prevent="
                                                    divisionId = {{ $division->id }};
                                                    textConfirmation = @js(__('divisions.modals.activate.confirmation_text'));
@@ -205,6 +197,24 @@
                                             >
                                                 @icon('check-circle', 'w-5 h-5 text-green-600')
                                                 {{ __('forms.activate') }}
+                                            </a>
+                                        @endcan
+
+                                        @can('deactivate', $division)
+                                            <a href="#"
+                                               wire:key="deactivate-{{ $division->id }}"
+                                               @click.prevent="
+                                                   divisionId= {{ $division->id }};
+                                                   textConfirmation = @js(__('divisions.modals.deactivate.confirmation_text'));
+                                                   actionType = 'deactivate';
+                                                   actionTitle = @js(__('divisions.modals.deactivate.title'));
+                                                   actionButtonText = @js(__('forms.deactivate'));
+                                                   open = !open;
+                                               "
+                                               class="flex items-center gap-2 w-full last-of-type:rounded-b-md px-4 py-2.5 text-left text-sm text-red-600 hover:bg-red-50"
+                                            >
+                                                @icon('delete', 'w-5 h-5 text-red-600')
+                                                {{ __('forms.deactivate') }}
                                             </a>
                                         @endcan
 

--- a/resources/views/livewire/division/division-view.blade.php
+++ b/resources/views/livewire/division/division-view.blade.php
@@ -1,7 +1,15 @@
+@use('App\Enums\Status')
+
 @php
     $action = 'show';
-    $status='';
-    $division = \App\Models\Division::find($divisionForm->division['id']);
+    // use livewire state for faster UI updates; normalize to string
+    $statusRaw = $divisionForm->division['status'] ?? null;
+    $statusStr = is_string($statusRaw) ? $statusRaw : ($statusRaw?->value ?? null);
+
+    $divisionId = $divisionForm->division['id'] ?? null;
+
+    // Model may be null if not preloaded; use for policy checks only
+    $division = $divisionId ? \App\Models\Division::find($divisionId) : null;
     $divisionType = dictionary()->getDictionary('DIVISION_TYPE', false)->getValue($divisionForm->division['type']);
     $uuid = $divisionForm->division['uuid'];
 @endphp
@@ -13,54 +21,58 @@
 @endsection
 
 @section('additional-buttons')
-    @can('update', $division)
-        <a role="button" class="default-button cursor-pointer" href="{{ route('division.edit', [legalEntity(), $divisionForm->division['id']]) }}">
-            {{ __('forms.edit') }}
-        </a>
-    @endcan
+    <div wire:key="division-actions-{{ $divisionForm->division['id'] }}-{{ $statusStr ?? 'unknown' }}" class="flex items-center gap-2">
 
-    @can('activate', $division)
-        <button
-            x-on:click.prevent="
-                divisionId={{ $division->id }};
-                textConfirmation=@js(__('divisions.modals.activate.confirmation_text'));
-                actionType='activate';
-                actionTitle=@js(__('divisions.modals.activate.title'));
-                actionButtonText=@js(__('forms.activate'));
-            "
-            class="alternative-button cursor-pointer mb-[8px]"
-        >
-            {{ __('forms.activate') }}
-        </button>
-    @endcan
+        @can('update', $division)
+            <a role="button" class="default-button cursor-pointer inline-flex items-center leading-none !mb-0" href="{{ route('division.edit', [legalEntity(), $divisionForm->division['id']]) }}">
+                {{ __('forms.edit') }}
+            </a>
+        @endcan
 
-    @can('deactivate', $division)
-        <button
-            x-on:click.prevent="
-                divisionId={{ $division->id }};
-                textConfirmation=@js(__('divisions.modals.deactivate.confirmation_text'));
-                actionType='deactivate';
-                actionTitle=@js(__('divisions.modals.deactivate.title'));
-                actionButtonText=@js(__('forms.deactivate'));
-            "
-            class="alternative-button cursor-pointer mb-[8px]"
-        >
-            {{ __('forms.deactivate') }}
-        </button>
-    @endcan
 
-    @can('delete', $division)
-        <button
-            x-on:click.prevent="
-                divisionId={{ $division->id }};
-                textConfirmation=@js(__('divisions.modals.delete.confirmation_text'));
-                actionType='delete';
-                actionTitle=@js(__('divisions.modals.delete.title'));
-                actionButtonText=@js(__('forms.delete'));
-            "
-            class="alternative-button cursor-pointer mb-[8px]"
-        >
-            {{ __('forms.delete') }}
-        </button>
-    @endcan
+        @can('activate', $division)
+            <button
+                x-on:click.prevent="
+                    divisionId={{ $divisionId }};
+                    textConfirmation=@js(__('divisions.modals.activate.confirmation_text'));
+                    actionType='activate';
+                    actionTitle=@js(__('divisions.modals.activate.title'));
+                    actionButtonText=@js(__('forms.activate'));
+                "
+                class="alternative-button cursor-pointer inline-flex items-center leading-none !mb-0"
+            >
+                {{ __('forms.activate') }}
+            </button>
+        @endcan
+
+        @can('deactivate', $division)
+            <button
+                x-on:click.prevent="
+                    divisionId={{ $divisionId }};
+                    textConfirmation=@js(__('divisions.modals.deactivate.confirmation_text'));
+                    actionType='deactivate';
+                    actionTitle=@js(__('divisions.modals.deactivate.title'));
+                    actionButtonText=@js(__('forms.deactivate'));
+                "
+                class="alternative-button cursor-pointer inline-flex items-center leading-none !mb-0"
+            >
+                {{ __('forms.deactivate') }}
+            </button>
+        @endcan
+
+        @can('delete', $division)
+            <button
+                x-on:click.prevent="
+                    divisionId={{ $divisionId }};
+                    textConfirmation=@js(__('divisions.modals.delete.confirmation_text'));
+                    actionType='delete';
+                    actionTitle=@js(__('divisions.modals.delete.title'));
+                    actionButtonText=@js(__('forms.delete'));
+                "
+                class="alternative-button cursor-pointer inline-flex items-center leading-none !mb-0"
+            >
+                {{ __('forms.delete') }}
+            </button>
+        @endcan
+    </div>
 @endsection

--- a/resources/views/livewire/division/modal/confirmation-modal.blade.php
+++ b/resources/views/livewire/division/modal/confirmation-modal.blade.php
@@ -41,7 +41,7 @@
                         <button
                             type="button"
                             @click="divisionId = 0"
-                            class="button-secondary"
+                            class="button-minor"
                         >
                             {{ __('forms.cancel') }}
                         </button>
@@ -50,7 +50,7 @@
                             type="button"
                             @click.prevent="$wire.$call(actionType, divisionId); divisionId = 0;"
                             wire:loading.attr="disabled"
-                            class="inline-flex justify-center rounded-lg border border-transparent bg-green-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+                            class="button-danger"
                             x-text="actionButtonText"
                         ></button>
                     </div>

--- a/resources/views/livewire/division/template/division.blade.php
+++ b/resources/views/livewire/division/template/division.blade.php
@@ -570,8 +570,8 @@
                         </div>
                     </fieldset>
 
-                    <div class="flex gap-2">
-                    <a role="button" class="alternative-button cursor-pointer" href="javascript:history.back()">
+                    <div class="flex gap-2 items-center additional-actions">
+                    <a role="button" class="alternative-button cursor-pointer !mb-0 inline-flex items-center leading-none" href="javascript:history.back()">
                         {{ __('forms.back') }}
                     </a>
 


### PR DESCRIPTION
This PR concerns to the #470 ISSUE

Що було зроблено:

- виправлено некоректну поведінку кнопок Активувати/Деактивувати в контексті меню і на сторінці "Переглянути";
- виправлено стилі (вирівнювання) action-кнопок (Назад, Зберегти, Видалити тощо) на сторінках Division;
- підкореговано стиль модального вікна-підтвердження.
 