### PR TITLE
#536: fix legalentity date bug

### DIFF
--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -44,12 +44,12 @@ if (!function_exists('convertToISO8601')) {
             return '';
         }
 
-        return CarbonImmutable::parse($dateString)->toIso8601String();
+        return CarbonImmutable::parse($dateString)->toIso8601ZuluString();
     }
 }
 
 if (!function_exists('convertToAppDateFormat')) {
-    function convertToAppDateFormat(string $dateString): string
+    function convertToAppDateFormat(?string $dateString): string
     {
         if (empty($dateString)) {
             return '';

--- a/app/Livewire/LegalEntity/LegalEntity.php
+++ b/app/Livewire/LegalEntity/LegalEntity.php
@@ -570,7 +570,7 @@ abstract class LegalEntity extends Component
             if (\is_array($itemValue)) {
                 $reformatted = collect($itemValue)->map(function($item) {
                     if (isset($item['date'])) {
-                        $item['date'] = convertToISO8601($item['date']);
+                        $item['date'] = convertToYmd($item['date']);
                     }
 
                     return $item;
@@ -578,7 +578,7 @@ abstract class LegalEntity extends Component
 
                 Arr::set($data, $item, $reformatted);
             } else {
-                Arr::set($data, $item, convertToISO8601($itemValue));
+                Arr::set($data, $item, convertToYmd($itemValue));
             }
         }
 


### PR DESCRIPTION
This PR concerns to the #536 ISSUE

Виправлено неспівпадіння формату дати між внутрішнім предствленням МІС і очікуваним в ЕСОЗ