### PR TITLE
#610: Refactoring migrations workflow

### DIFF
--- a/app/Console/Commands/Install.php
+++ b/app/Console/Commands/Install.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Console\Commands;
+
+use Exception;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use App\Console\Commands\MigrationsCommand;
+
+class Install extends MigrationsCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'install {--clear : Clear the cache before installation} {--wipe : Wipe the database before installation} {--key : Generate application key}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Setup system for first use';
+
+    /**
+     * Set the migrations path (and supply stuff aka seeders) for the application
+     *
+     * This method configures the path where database migration files (and seeders) are located
+     * or should be executed from during the installation process.
+     *
+     * @return void
+     */
+    protected function setMigrationsPath(): void
+    {
+        $this->migrations_path = config('ehealth.migrations.install.path', database_path('migrations/install'));
+    }
+
+    /**
+     * Execute actions before running database migrations
+     *
+     * This method is called during the installation process before any database
+     * migrations are executed. It can be used to perform preparatory tasks such as
+     * checking database connectivity, creating initial configuration, or setting up
+     * required database structures
+     *
+     * @return void
+     */
+    protected function beforeMigrations(): void
+    {
+        // Prepare options
+        $this->options['wipe'] = $this->option('wipe');
+        $this->options['key'] = $this->option('key');
+
+        $this->newLine();
+        $this->components->info('Start installation...');
+        $this->newLine();
+
+        // Completely wipe the database before installation
+        if ($this->options['wipe']) {
+            $this->call('db:wipe');
+
+            $this->call('migrate:install');
+        }
+
+        // Generate application key
+        if ($this->options['key']) {
+            $this->info('Generating new application key...');
+
+            $this->call('key:generate');
+        }
+    }
+
+    /**
+     * Performs post-migration setup tasks
+     *
+     * This method is called after database migrations have been succesfully! executed.
+     * It can be used to seed data, configure application settings, or perform
+     * any other necessary initialization tasks that depend on the database schema.
+     *
+     * @return void
+     */
+    protected function afterMigrations(): void
+    {
+        $this->newLine();
+
+        $this->fixAllPostgresSequences();
+
+        $this->components->info('Installation completed successfully.');
+    }
+
+    /**
+     * Fixes PostgreSQL sequences for all relevant tables.
+     *
+     * @return void
+     */
+    protected function fixAllPostgresSequences(): void
+    {
+        if (DB::connection()->getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        $tables = [
+            'users',
+            'legal_entities',
+            'parties',
+            'employees',
+            'employee_requests',
+            'revisions'
+        ];
+
+        foreach ($tables as $tableName) {
+            $this->fixPostgresSequence($tableName);
+        }
+    }
+
+    /**
+     * Resets the sequence for a given table to the current maximum ID.
+     * This version is more robust and handles empty tables correctly.
+     *
+     * @param string $tableName
+     * @return void
+     */
+    protected function fixPostgresSequence(string $tableName): void
+    {
+        try {
+            DB::statement(
+                "SELECT setval(pg_get_serial_sequence('{$tableName}', 'id'), COALESCE((SELECT MAX(id) FROM \"{$tableName}\"), 0));"
+            );
+        } catch (Exception $e) {
+            Log::warning("Could not reset sequence for table '{$tableName}': " . $e->getMessage());
+        }
+    }
+}

--- a/app/Console/Commands/MigrationsCommand.php
+++ b/app/Console/Commands/MigrationsCommand.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Migrations\Migrator;
+
+abstract class MigrationsCommand extends Command
+{
+    // Flag indicating whether the command is performing a rollback operation.
+    protected bool $isRollback = false;
+
+    // Paths to migration files
+    protected string $migrations_path;
+
+    // Path to migration seeders
+    protected string $migrations_seeders_path;
+
+    // Array of migration files to be processed
+    protected array $migrationFiles = [];
+
+    // Options passed to the command
+    protected array $options;
+
+    // Arguments passed to the command
+    protected array $arguments;
+
+    // Set the migrations path and seeders path
+    abstract protected function setMigrationsPath(): void;
+
+    // Execute actions before running database migrations
+    abstract protected function beforeMigrations(): void;
+
+    // Execute actions after running database migrations
+    abstract protected function afterMigrations(): void;
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(Migrator $migrator): void
+    {
+        $this->cacheClear();
+
+        $this->beforeMigrations();
+
+        if (!$this->setMigrationsFiles($migrator)) {
+            return;
+        }
+
+        // Rollback mode: if --rollback provided, perform rollback and exit
+        if ($this->isRollback) {
+            $this->doRollback($migrator);
+
+            return;
+        }
+
+        $this->doMigrations($migrator);
+
+        $this->afterMigrations();
+    }
+
+    protected function cacheClear(): void
+    {
+        $isCacheCleared = (bool) ($this->option('clear') ?? false);
+
+        if (! $isCacheCleared) {
+            return;
+        }
+
+        $this->info('Clearing cache...');
+
+        $this->call('cache:clear');
+        $this->call('config:clear');
+        $this->call('config:cache');
+        $this->call('route:clear');
+        $this->call('view:clear');
+
+        $this->info('Cache cleared.');
+    }
+
+    // Get the migration files to be processed
+    protected function getMigrationFiles(): array
+    {
+        return $this->migrationFiles;
+    }
+
+    // Set the migration files to be processed (only those that have not been run yet)
+    protected function setMigrationsFiles(Migrator $migrator): bool
+    {
+        $this->setMigrationsPath();
+
+        // Get migration files from the specified path
+        $this->migrationFiles = $migrator->getMigrationFiles($this->migrations_path);
+
+        if (empty($this->migrationFiles)) {
+            $this->warn("No migration files found in the path: {$this->migrations_path}");
+
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function doRollback(Migrator $migrator): void
+    {
+        $this->setMigrationsPath();
+
+        $step = $this->option('step');
+
+        if (!empty($step)) {
+            $this->info("Rolling back {$step} batch(es) of migrations...");
+
+            // Laravel's rollback supports --step; call the artisan command to leverage options
+            $this->call('migrate:rollback', [
+                '--path' => $this->migrations_path,
+                '--step' => (int) $step,
+            ]);
+        } else {
+            $this->info('Rolling back last batch of migrations...');
+
+            // Use Migrator directly for the given path (last batch)
+            $migrator->rollback($this->migrations_path);
+        }
+    }
+
+    // Perform the migrations (depends on the $migrationFiles set previously)
+    protected function doMigrations(Migrator $migrator): void
+    {
+        if($migrator->hasRunAnyMigrations()) {
+            // Filter out already run migrations
+            $migrationsAlreadyCompleted = $migrator?->getRepository()?->getRan() ?? [];
+
+            $migrationsToRun = \array_diff(\array_keys($this->migrationFiles), $migrationsAlreadyCompleted);
+
+            if (empty($migrationsToRun)) {
+                $this->warn('All migrations have already been run.');
+                $this->newLine();
+
+                return;
+            };
+        } else {
+            $migrationsToRun = \array_keys($this->migrationFiles);
+        }
+
+        $pendingFiles = [];
+
+        /**
+         * $migrationFiles - is a key-value array where key is the migration class name and value is the full path to the migration file
+         *
+         *  Here we prepare an array of pending migration files to be run.
+         *  Pass to migrator only those files that have not been run yet.
+         */
+        foreach ($migrationsToRun as $key) {
+            $pendingFiles[] = $this->migrationFiles[$key];
+        }
+
+        natsort($pendingFiles);
+
+        $this->info("Running all the new migrations:");
+        $this->newLine();
+
+        // Apply all the migrations at one time
+        $migrator->run($pendingFiles);
+
+        // Run the pending migrations
+        foreach ($pendingFiles as $file) {
+            $this->line("<comment>   Proceeded: </comment>{$file}");
+        }
+    }
+}

--- a/app/Console/Commands/Update.php
+++ b/app/Console/Commands/Update.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Console\Commands\MigrationsCommand;
+
+class Update extends MigrationsCommand
+{
+    protected string $version = '0_1';
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'update {--clear : Clear the cache before installation} {--rollback : Rollback the last batch of migrations} {--step=0 : The number of migration batches to rollback} {--ver= : Specify the target version to update to}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update the system\'s base tables and data to the latest version';
+
+    /**
+     * Set the migrations path (and supply stuff aka seeders) for the application
+     *
+     * This method configures the path where database migration files (and seeders) are located
+     * or should be executed from during the installation process.
+     *
+     * @return void
+     */
+    protected function setMigrationsPath(): void
+    {
+        $this->migrations_path = config('ehealth.migrations.update.path', database_path('migrations/update')) . '/' . $this->version;
+    }
+
+    /**
+     * Execute actions before running database migrations
+     *
+     * This method is called during the installation process before any database
+     * migrations are executed. It can be used to perform preparatory tasks such as
+     * checking database connectivity, creating initial configuration, or setting up
+     * required database structures
+     *
+     * @return void
+     */
+    protected function beforeMigrations(): void
+    {
+        $this->isRollback = (bool) ($this->option('rollback') ?? false);
+
+        $this->version = $this->getVersion();
+
+        $this->newLine();
+        $this->components->info($this->isRollback ? 'Start DB rollback...' : 'Start DB update...');
+        $this->newLine();
+    }
+
+    /**
+     * Performs post-migration setup tasks
+     *
+     * This method is called after database migrations have been succesfully! executed.
+     * It can be used to seed data, configure application settings, or perform
+     * any other necessary initialization tasks that depend on the database schema.
+     *
+     * @return void
+     */
+    protected function afterMigrations(): void
+    {
+        $this->newLine();
+
+        $this->components->info('DB update completed successfully.');
+    }
+
+    /**
+     * Get the current version of the application.
+     *
+     * This metod expected the version to be provided via the --ver option and it value must be in format x.y.z
+     *
+     * @return string The current version of the application in format x_y_z
+     */
+    protected function getVersion(): string
+    {
+        $version = $this->option('ver') ?? config('ehealth.migrations.update.version.curr');
+
+        return str_replace('.', '_', $version)  ;
+    }
+}

--- a/app/Core/ExtendedMigration.php
+++ b/app/Core/ExtendedMigration.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Migrations\Migration;
+
+class ExtendedMigration extends Migration
+{
+    /**
+     * Creates a backup of the provided data during migration.
+     *
+     * This method is responsible for storing backup data that can be used
+     * to restore the system state if the migration needs to be rolled back.
+     *
+     * @param mixed $backupData
+     *
+     * @return void
+     */
+    protected function backup(mixed $backupData): void
+    {
+        $file = new \ReflectionClass(static::class)->getFileName();
+        $migrationName = $file ? pathinfo($file, PATHINFO_FILENAME) : static::class;
+
+        $json = json_encode($backupData, JSON_THROW_ON_ERROR);
+
+        // Compress the JSON data to  reduce storage size
+        $compressed = gzcompress($json);
+
+        $wrapped = base64_encode($compressed);
+
+        DB::table('migration_backups')->updateOrInsert(
+            ['migration' => $migrationName],
+            [
+                'data' => $wrapped,
+                'created_at' => now(),
+                'updated_at' => now()
+            ]
+        );
+    }
+
+    /**
+     * Restore the previous state or data.
+     *
+     * This method is responsible for restoring data or reverting changes
+     * that were made during the migration process. It is typically called
+     * when rolling back a migration or undoing specific operations.
+     *
+     * @return mixed The restored data or state, return type depends on implementation
+     */
+    protected function restore(): mixed
+    {
+        $file = (new \ReflectionClass(static::class))->getFileName();
+        $migrationName = $file
+            ? pathinfo($file, PATHINFO_FILENAME)
+            : static::class;
+
+        $encoded = DB::table('migration_backups')
+            ->where('migration', $migrationName)
+            ->value('data');
+
+        if (!$encoded) {
+            return null;
+        }
+
+        $unwrapped = base64_decode($encoded, true);
+
+        if ($unwrapped === false) {
+            throw new \RuntimeException("Invalid base64 backup for migration {$migrationName}");
+        }
+
+        $json = gzuncompress($unwrapped);
+
+        if ($json === false) {
+            throw new \RuntimeException("Invalid compressed backup for migration {$migrationName}");
+        }
+
+        return json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/app/Models/Migration.php
+++ b/app/Models/Migration.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class Migration extends Model
+{
+    protected $table = 'migrations';
+
+    public $timestamps = false;
+
+    protected $primaryKey = 'id';
+
+    protected $fillable = [
+        'migration',
+        'batch'
+    ];
+
+    protected $casts = [
+        'batch' => 'integer',
+    ];
+
+    /**
+     * Get the backup associated with the migration.
+     *
+     * @return HasOne
+     */
+    public function backup(): HasOne
+    {
+        return $this->hasOne(MigrationBackup::class, 'migration_id', 'id');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,9 @@
         ],
         "psr-4": {
             "App\\": "app/",
-            "Database\\Seeders\\": "database/seeders/"
+            "Database\\Seeders\\": "database/seeders/",
+            "Database\\Migrations\\Install\\": "database/migrations/install/",
+            "Database\\Migrations\\Update\\": "database/migrations/update/"
         }
     },
     "autoload-dev": {

--- a/config/ehealth.php
+++ b/config/ehealth.php
@@ -847,5 +847,18 @@ return [
         'd.m.Y' => 'dd.mm.yyyy',
         'd/m/Y' => 'dd/mm/yyyy',
         'Y-m-d' => 'yyyy-mm-dd',
+    ],
+
+    'migrations' => [
+        'install' => [
+            'path' => 'database/migrations/install'
+        ],
+        'update' => [
+            'version' => [
+                'prev' => '',
+                'curr' => env('APP_VERSION', '0.1')
+            ],
+            'path' => 'database/migrations/update'
+        ]
     ]
 ];

--- a/database/migrations/install/2021_01_01_000000_create_persons_table.php
+++ b/database/migrations/install/2021_01_01_000000_create_persons_table.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('persons', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid();
+            $table->enum('verification_status', ['CHANGES_NEEDED', 'IN_REVIEW', 'NOT_VERIFIED', 'VERIFICATION_NEEDED', 'VERIFICATION_NOT_NEEDED', 'VERIFIED'])->default('IN_REVIEW');
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('second_name')->nullable();
+            $table->date('birth_date');
+            $table->string('birth_country')->nullable();
+            $table->string('birth_settlement')->nullable();
+            $table->enum('gender', ['MALE', 'FEMALE']);
+            $table->string('email')->unique()->nullable();
+            $table->boolean('no_tax_id')->nullable();
+            $table->string('tax_id')->unique()->nullable();
+            $table->string('secret')->nullable();
+            $table->string('unzr')->unique()->nullable();
+            $table->jsonb('emergency_contact')->nullable();
+            $table->boolean('patient_signed')->default(false)->comment("Person's evidence of sign the person request");
+            $table->boolean('process_disclosure_data_consent')->default(true)->comment("Person's evidence of information about consent to data disclosure");
+            $table->date('death_date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('persons');
+    }
+};

--- a/database/migrations/install/2023_06_20_000002_create_password_reset_tokens_table.php
+++ b/database/migrations/install/2023_06_20_000002_create_password_reset_tokens_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('password_reset_tokens', function (Blueprint $table) {
+            $table->string('email')->primary();
+            $table->string('token');
+            $table->timestamp('created_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('password_reset_tokens');
+    }
+};

--- a/database/migrations/install/2025_12_10_000004_create_failed_jobs_table.php
+++ b/database/migrations/install/2025_12_10_000004_create_failed_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_jobs');
+    }
+};

--- a/database/migrations/install/2025_12_10_000006_create_personal_access_tokens_table.php
+++ b/database/migrations/install/2025_12_10_000006_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/database/migrations/install/2025_12_10_000008_create_sessions_table.php
+++ b/database/migrations/install/2025_12_10_000008_create_sessions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sessions', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->longText('payload');
+            $table->integer('last_activity')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sessions');
+    }
+};

--- a/database/migrations/install/2025_12_10_000010_create_jobs_table.php
+++ b/database/migrations/install/2025_12_10_000010_create_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+    }
+};

--- a/database/migrations/install/2025_12_10_000012_create_legal_entity_types_table.php
+++ b/database/migrations/install/2025_12_10_000012_create_legal_entity_types_table.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LegalEntity;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('legal_entity_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('localized_name')->nullable();
+            $table->timestamps();
+        });
+
+        try {
+            $this->setData();
+        } catch (Exception $error) {
+            $this->down();
+
+            throw $error;
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('legal_entity_types');
+    }
+
+    /**
+     * Set the initial data for the legal_entity_types table.
+     *
+     * @return void
+     */
+    protected function setData(): void
+    {
+        $now = now();
+
+        $availableTypes = [
+            ['name' => LegalEntity::TYPE_EMERGENCY, 'localized_name' => 'legal-entity.types.emergency'],
+            ['name' => LegalEntity::TYPE_MIS, 'localized_name' => 'legal-entity.types.mis'],
+            ['name' => LegalEntity::TYPE_MSP, 'localized_name' => 'legal-entity.types.msp'],
+            ['name' => LegalEntity::TYPE_MSP_PHARMACY, 'localized_name' => 'legal-entity.types.msp_pharmacy'],
+            ['name' => LegalEntity::TYPE_NHS, 'localized_name' => 'legal-entity.types.nhs'],
+            ['name' => LegalEntity::TYPE_OUTPATIENT, 'localized_name' => 'legal-entity.types.outpatient'],
+            ['name' => LegalEntity::TYPE_PHARMACY, 'localized_name' => 'legal-entity.types.pharmacy'],
+            ['name' => LegalEntity::TYPE_PRIMARY_CARE, 'localized_name' => 'legal-entity.types.primary_care'],
+            ['name' => LegalEntity::TYPE_MSP_LIMITED, 'localized_name' => 'legal-entity.types.msp_limited']
+        ];
+
+        foreach ($availableTypes as $typeRecord) {
+            $typeRecord['created_at'] = $now;
+            $typeRecord['updated_at'] = $now;
+        }
+
+        DB::table('legal_entity_types')->insert($availableTypes);
+    }
+};

--- a/database/migrations/install/2025_12_10_000014_create_legal_entities_table.php
+++ b/database/migrations/install/2025_12_10_000014_create_legal_entities_table.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\JobStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('legal_entities', function (Blueprint $table) {
+            $table->id();
+            $table->uuid();
+            $table->json('accreditation')->nullable();
+            $table->json('archive')->nullable();
+            $table->string('beneficiary')->nullable();
+            $table->json('edr')->nullable();
+            $table->boolean('edr_verified')->nullable();
+            $table->string('edrpou')->nullable();
+            $table->string('email')->nullable();
+            $table->uuid('inserted_by')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->text('nhs_comment')->nullable();
+            $table->boolean('nhs_reviewed')->default(false);
+            $table->boolean('nhs_verified')->default(false);
+            $table->string('receiver_funds_code')->nullable();
+            $table->string('status')->nullable();
+            $table->foreignId('legal_entity_type_id')->constrained('legal_entity_types')->cascadeOnDelete();
+            $table->uuid('updated_by')->nullable();
+            $table->string('client_id')->nullable();
+            $table->string('client_secret')->nullable();
+            $table->string('website')->nullable();
+            $table->enum('sync_status', JobStatus::values())->nullable();
+            $table->enum('division_sync_status', JobStatus::values())->nullable();
+            $table->enum('hcs_sync_status', JobStatus::values())->nullable();
+            $table->enum('employee_sync_status', JobStatus::values())->nullable();
+            $table->enum('license_sync_status', JobStatus::values())->nullable();
+            $table->enum('document_sync_status', JobStatus::values())->nullable();
+            $table->timestamp('inserted_at')->nullable();
+            $table->date('ehealth_inserted_at')->nullable();
+            $table->uuid('ehealth_inserted_by')->nullable();
+            $table->date('ehealth_updated_at')->nullable();
+            $table->uuid('ehealth_updated_by')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('legal_entities');
+    }
+};

--- a/database/migrations/install/2025_12_10_000016_create_permission_tables.php
+++ b/database/migrations/install/2025_12_10_000016_create_permission_tables.php
@@ -1,0 +1,331 @@
+<?php
+
+use App\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Spatie\Permission\PermissionRegistrar;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    protected const int CHUNK_SIZE = 1000;
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $teams = config('permission.teams');
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+        $pivotRole = $columnNames['role_pivot_key'] ?? 'role_id';
+        $pivotPermission = $columnNames['permission_pivot_key'] ?? 'permission_id';
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+        if ($teams && empty($columnNames['team_foreign_key'] ?? null)) {
+            throw new \Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+
+        Schema::create($tableNames['permissions'], function (Blueprint $table) {
+            $table->bigIncrements('id'); // permission id
+            $table->string('name');       // For MySQL 8.0 use string('name', 125);
+            $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create($tableNames['roles'], function (Blueprint $table) use ($teams, $columnNames) {
+            $table->bigIncrements('id'); // role id
+            if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+
+                $table->foreign($columnNames['team_foreign_key'])
+                    ->references('id')
+                    ->on($columnNames['team_foreign_key_constraint_table'])
+                    ->onDelete('cascade');
+            }
+            $table->string('name');       // For MySQL 8.0 use string('name', 125);
+            $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
+            $table->timestamps();
+            if ($teams || config('permission.testing')) {
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+            } else {
+                $table->unique(['name', 'guard_name']);
+            }
+        });
+
+        Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames, $pivotPermission, $teams) {
+            $table->unsignedBigInteger($pivotPermission);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            } else {
+                $table->primary([$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            }
+
+        });
+
+        Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames, $pivotRole, $teams) {
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+
+                $table->foreign($columnNames['team_foreign_key'])
+                    ->references('id')
+                    ->on($columnNames['team_foreign_key_constraint_table'])
+                    ->onDelete('cascade');
+
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            } else {
+                $table->primary([$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            }
+        });
+
+        Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames, $pivotRole, $pivotPermission) {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+        });
+
+        app('cache')
+            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+
+        try {
+            $this->setLegalEntityRoles();
+
+            $this->setPermissions();
+
+            $this->setRolePermissions();
+        } catch (Exception $error) {
+            $this->down();
+
+            throw $error;
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $tableNames = config('permission.table_names');
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
+        }
+
+        Schema::drop($tableNames['role_has_permissions']);
+        Schema::drop($tableNames['model_has_roles']);
+        Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['roles']);
+        Schema::drop($tableNames['permissions']);
+    }
+
+    /**
+     * Set up roles specific to legal entities.
+     *
+     * @return void
+     */
+    protected function setLegalEntityRoles(): void
+    {
+        $now = now();
+
+        $rolesToInsert = [];
+
+        // Get all specified guards from section 'guards' from file config/auth.php (except sanctum)
+        $guards = collect(array_keys((array) config('auth.guards')))
+            ->reject(fn ($guard) => $guard === 'sanctum')
+            ->values();
+
+        $roleList = array_keys(config('ehealth.roles'));
+
+        // Prepare Role's and Permission's data to insert into DB
+        foreach ($guards as $guard) {
+            foreach ($roleList as $roleName) {
+                $rolesToInsert[] = [
+                    'name' => $roleName,
+                    'guard_name' => $guard,
+                    'created_at' => $now,
+                    'updated_at' => $now
+                ];
+            }
+        }
+
+        DB::table('roles')->insert($rolesToInsert);
+    }
+
+    /**
+     * Set up the default permissions for the application.
+     *
+     * @return void
+     */
+    protected function setPermissions(): void
+    {
+        // Ensure that no cached permission state during seeding
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        // Collect all types permissions from config source
+        $typePermissions = collect((array) config('ehealth.legal_entity_types'))
+            ->flatMap(fn ($arr) => (array) $arr);
+
+        // Collect all roles permissions from config source
+        $rolePermissions = collect((array) config('ehealth.roles'))
+            ->flatMap(fn ($arr) => (array) $arr);
+
+        // Combine and deduplicate permission names
+        $allNames = $typePermissions
+            ->merge($rolePermissions)
+            ->filter(fn ($v) => is_string($v) && trim($v) !== '')
+            ->map(fn ($v) => trim($v))
+            ->unique()
+            ->values();
+
+        // Get available guards except sanctum
+        $guards = collect(array_keys((array) config('auth.guards')))
+            ->reject(fn ($g) => $g === 'sanctum')
+            ->values();
+
+        $now = now();
+        $dataToInsert = [];
+
+        foreach ($guards as $guard) {
+            foreach ($allNames as $name) {
+                $dataToInsert[] = [
+                    'name' => $name,
+                    'guard_name' => $guard,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            }
+        }
+
+        // Insert data into table by chunks or ignore duplicates
+        foreach (array_chunk($dataToInsert, self::CHUNK_SIZE) as $chunk) {
+            DB::table(config('permission.table_names.permissions'))
+                ->insertOrIgnore($chunk);
+        }
+
+        // Clear cached permissions again
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    /**
+     * Set up default role permissions for the application.
+     *
+     * @return void
+     */
+    protected function setRolePermissions(): void
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        // Get all guards except sanctum
+        $guards = collect(array_keys((array) config('auth.guards')))
+            ->reject(fn ($g) => $g === 'sanctum')
+            ->values();
+
+        // Get roles from config
+        $rolesData = (array) config('ehealth.roles');
+
+        // Extract names of roles
+        $roleNames = array_keys($rolesData);
+
+        foreach ($guards as $guard) {
+            // Prepare permission map for this guard: permission name -> id
+            $permMap = Permission::where('guard_name', $guard)
+                ->get(['id', 'name'])
+                ->keyBy('name')
+                ->map(fn ($p) => (int) $p->id);
+
+            // Get roles existing for this guard: role name -> id
+            $roleMap = Role::whereIn('name', $roleNames)
+                ->where('guard_name', $guard)
+                ->get(['id', 'name'])
+                ->keyBy('name')
+                ->map(fn ($r) => (int) $r->id);
+
+            $dataToInsert = [];
+
+            foreach ($rolesData as $roleName => $roleScopes) {
+                $roleId = $roleMap[$roleName] ?? null;
+
+                if (!$roleId) {
+                    // If role not present for this guard
+                    continue;
+                }
+
+                // Get scopes from config
+                $roleScopes = collect((array) $roleScopes)
+                    ->filter(fn ($v) => is_string($v) && $v !== '');
+
+                // Get permission IDs for this role's scopes
+                $permIds = $roleScopes
+                    ->unique()
+                    ->map(fn ($name) => $permMap[$name] ?? null) // Here should be array of IDs
+                    ->filter()
+                    ->values();
+
+                foreach ($permIds as $pid) {
+                    $dataToInsert[] = [
+                        'role_id' => $roleId,
+                        'permission_id' => (int) $pid,
+                    ];
+                }
+            }
+
+            // Insert data into table by chunks for this guard
+            if (!empty($dataToInsert)) {
+                foreach (array_chunk($dataToInsert, self::CHUNK_SIZE) as $chunk) {
+                    DB::table(config('permission.table_names.role_has_permissions'))
+                        ->insertOrIgnore($chunk);
+                }
+            }
+        }
+
+        // Clear permission cache
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+};

--- a/database/migrations/install/2025_12_10_000018_create_legal_entity_type_roles.php
+++ b/database/migrations/install/2025_12_10_000018_create_legal_entity_type_roles.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Models\Role;
+use App\Models\LegalEntityType;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('legal_entity_type_roles', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('legal_entity_type_id')->constrained()->cascadeOnDelete();
+
+            $table->primary(['role_id', 'legal_entity_type_id']);
+
+            $table->timestamps();
+
+            $table->unique(['role_id', 'legal_entity_type_id']);
+        });
+
+        try {
+            $this->setData();
+        } catch (Exception $error) {
+            $this->down();
+
+            throw $error;
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('legal_entity_type_roles');
+    }
+
+    /**
+     * Set up the legal entity type roles in the database.
+     *
+     * @return void
+     */
+    protected function setData(): void
+    {
+        $now = now();
+
+        $roleAndTypePairs = [];
+
+        $availableRoles = Role::get(['id', 'name'])
+                ->groupBy('name')
+                ->map(fn ($group) => $group->pluck('id')->values()->all())
+                ->toArray();
+
+        $roleNames = array_keys($availableRoles);
+
+        $legalEntityTypes = LegalEntityType::all()->keyBy('name')->toArray();
+
+        foreach (config('ehealth.legal_entity_employee_types') as $legalEntityType => $roles) {
+            foreach ($roles as $role) {
+                if (in_array($role, $roleNames, true)) {
+                    $legalEtntityTypeId = $legalEntityTypes[$legalEntityType]['id'];
+
+                    foreach ($availableRoles[$role] as $roleId) {
+                        $roleAndTypePairs[] = [
+                            'legal_entity_type_id' => $legalEtntityTypeId,
+                            'role_id' => $roleId,
+                            'created_at' => $now,
+                            'updated_at' => $now,
+                        ];
+                    }
+                } else {
+                    echo "ERROR: Role '{$role}' not found in the configuration.";
+                }
+            }
+        }
+
+        DB::table('legal_entity_type_roles')->insert($roleAndTypePairs);
+    }
+};

--- a/database/migrations/install/2025_12_10_000020_create_legal_entity_type_permissions_table.php
+++ b/database/migrations/install/2025_12_10_000020_create_legal_entity_type_permissions_table.php
@@ -1,0 +1,83 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    protected const int CHUNK_SIZE = 1000;
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('legal_entity_type_permissions', function (Blueprint $table) {
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('legal_entity_type_id')->constrained()->cascadeOnDelete();
+
+            $table->primary(['permission_id', 'legal_entity_type_id']);
+
+            $table->timestamps();
+        });
+
+        try {
+            $this->setData();
+        } catch (Exception $error) {
+            $this->down();
+
+            throw $error;
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('legal_entity_type_permissions');
+    }
+
+    /**
+     * Set up default permissions for legal entity types
+     *
+     * @return void
+     */
+    protected function setData(): void
+    {
+        $typesData= config('ehealth.legal_entity_types', []);
+
+        // Fetch type ids keyed by name
+        $typeIds = DB::table('legal_entity_types')->pluck('id', 'name');
+
+        // Map permission name => [permission_id => [...guards]] (include all guards)
+        $permMap = DB::table('permissions')
+            ->select('id', 'name')
+            ->get()
+            ->groupBy('name')
+            ->map(fn ($dataToInsert) => $dataToInsert->pluck('id')->all());
+
+        $dataToInsert = [];
+
+        foreach ($typesData as $typeName => $permNames) {
+
+            $typeId = (int) $typeIds[$typeName];
+
+            foreach ($permNames as $name) {
+
+                foreach ($permMap[$name] as $pid) {
+                    $dataToInsert[] = [
+                        'permission_id' => (int) $pid,
+                        'legal_entity_type_id' => $typeId,
+                    ];
+                }
+            }
+        }
+
+        // Insert in chunks using insertOrIgnore for idempotency
+        foreach (array_chunk($dataToInsert, self::CHUNK_SIZE) as $chunk) {
+            DB::table('legal_entity_type_permissions')->insertOrIgnore($chunk);
+        }
+    }
+};

--- a/database/migrations/install/2025_12_10_000022_create_divisions_table.php
+++ b/database/migrations/install/2025_12_10_000022_create_divisions_table.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Status;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    protected const array VALID_STATUSES = [
+        'ACTIVE',
+        'INACTIVE',
+        'DRAFT',
+        'UNSYNCED'
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('divisions', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique()->nullable();
+            $table->string('external_id')->nullable();
+            $table->string('name');
+            $table->string('type')->nullable();
+            $table->boolean('mountain_group');
+            $table->jsonb('location')->nullable();
+            $table->string('email');
+            $table->jsonb('working_hours')->nullable();
+            $table->boolean('is_active')->default(false);
+            $table->foreignId('legal_entity_id')->constrained('legal_entities')->cascadeOnDelete()->cascadeOnUpdate();
+            $table->enum('status', Status::only(self::VALID_STATUSES))->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('divisions');
+    }
+};

--- a/database/migrations/install/2025_12_10_000024_create_parties_table.php
+++ b/database/migrations/install/2025_12_10_000024_create_parties_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('parties', function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique()->nullable();
+            $table->string('last_name');
+            $table->string('first_name');
+            $table->string('second_name')->nullable();
+            $table->date('birth_date')->nullable();
+            $table->string('gender')->nullable();
+            $table->string('tax_id')->nullable()->index();
+            $table->boolean('no_tax_id')->nullable()->default(false);
+            $table->text('about_myself')->nullable();
+            $table->string('verification_status')->nullable()->comment('Overall verification status');
+            $table->integer('working_experience')->nullable();
+            $table->integer('declaration_count')->nullable();
+            $table->integer('declaration_limit')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('parties');
+    }
+};

--- a/database/migrations/install/2025_12_10_000026_create_contracts_table.php
+++ b/database/migrations/install/2025_12_10_000026_create_contracts_table.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('contracts', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid('uuid')->unique();
+            $table->foreignId('legal_entity_id')->constrained('legal_entities');
+            $table->uuid('contractor_legal_entity_id');
+            $table->uuid('contractor_owner_id');
+            $table->string('contractor_base');
+            $table->jsonb('contractor_payment_details');
+            $table->string('contractor_rmsp_amount')->nullable();
+            $table->boolean('external_contractor_flag')->default(false);
+            $table->jsonb('external_contractors')->nullable();
+            $table->jsonb('contractor_employee_divisions')->nullable();
+            $table->jsonb('contractor_divisions')->nullable();
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->uuid('nhs_legal_entity_id')->nullable();
+            $table->uuid('nhs_signer_id')->nullable();
+            $table->string('nhs_signer_base')->nullable();
+            $table->string('issue_city')->nullable(); // The city is filled in when signing
+            $table->double('nhs_contract_price')->nullable(); // The price can be null
+            $table->string('contract_number')->nullable(); // The number is assigned later
+            $table->uuid('contract_id')->nullable(); // The ID of the current contract will appear later
+            $table->uuid('assignee_id')->nullable();
+            $table->string('status');
+            $table->string('status_reason')->nullable();
+            $table->string('nhs_payment_method')->nullable();
+            $table->date('nhs_signed_date')->nullable();
+            $table->uuid('previous_request_id')->nullable();
+            $table->jsonb('data')->nullable();
+            $table->string('id_form')->nullable();
+            $table->uuid('inserted_by')->nullable();
+            $table->timestamp('inserted_at');
+            $table->uuid('updated_by')->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->jsonb('medical_programs')->nullable();
+            $table->string('type')->nullable();
+            $table->boolean('contractor_signed')->default(false);
+            $table->text('misc')->nullable();
+            $table->string('statute_md5')->nullable();
+            $table->string('additional_document_md5')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('contracts');
+    }
+};

--- a/database/migrations/install/2025_12_10_000028_create_licenses_table.php
+++ b/database/migrations/install/2025_12_10_000028_create_licenses_table.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\License\Type;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::create('licenses', static function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique()->nullable();
+            $table->foreignId('legal_entity_id')->constrained()->cascadeOnDelete();
+            $table->enum('type', Type::values());
+            $table->boolean('is_active')->nullable();
+            $table->string('issued_by');
+            $table->date('issued_date');
+            $table->string('issuer_status')->nullable();
+            $table->date('active_from_date');
+            $table->string('order_no');
+            $table->string('license_number')->nullable();
+            $table->date('expiry_date')->nullable();
+            $table->string('what_licensed');
+            $table->boolean('is_primary')->default(false);
+            $table->date('ehealth_inserted_at')->nullable();
+            $table->uuid('ehealth_inserted_by')->nullable();
+            $table->date('ehealth_updated_at')->nullable();
+            $table->uuid('ehealth_updated_by')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('licenses');
+    }
+};

--- a/database/migrations/install/2025_12_10_000030_create_documents_table.php
+++ b/database/migrations/install/2025_12_10_000030_create_documents_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('documents', function (Blueprint $table) {
+            $table->id();
+            $table->string('type');
+            $table->string('number');
+            $table->string('issued_by')->nullable();
+            $table->date('issued_at')->nullable();
+            $table->date('expiration_date')->nullable();
+            $table->morphs('documentable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('documents');
+    }
+};

--- a/database/migrations/install/2025_12_10_000032_create_phones_table.php
+++ b/database/migrations/install/2025_12_10_000032_create_phones_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('phones', static function (Blueprint $table) {
+            $table->id();
+            $table->string('number');
+            $table->string('type');
+            $table->morphs('phoneable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('phones');
+    }
+};

--- a/database/migrations/install/2025_12_10_000034_create_educations_table.php
+++ b/database/migrations/install/2025_12_10_000034_create_educations_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('educations', function (Blueprint $table) {
+            $table->id();
+            $table->string('country');
+            $table->string('city');
+            $table->string('institution_name');
+            $table->date('issued_date')->nullable();
+            $table->string('diploma_number');
+            $table->string('degree');
+            $table->string('speciality');
+            $table->morphs('educationable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('educations');
+    }
+};

--- a/database/migrations/install/2025_12_10_000036_create_qualifications_table.php
+++ b/database/migrations/install/2025_12_10_000036_create_qualifications_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('qualifications', function (Blueprint $table) {
+            $table->id();
+            $table->string('type');
+            $table->string('institution_name');
+            $table->string('speciality');
+            $table->date('issued_date');
+            $table->string('certificate_number');
+            $table->date('valid_to')->nullable();
+            $table->string('additional_info')->nullable();
+            $table->morphs('qualificationable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('qualifications');
+    }
+};

--- a/database/migrations/install/2025_12_10_000038_create_specialities_table.php
+++ b/database/migrations/install/2025_12_10_000038_create_specialities_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('specialities', function (Blueprint $table) {
+            $table->id();
+            $table->string('speciality');
+            $table->boolean('speciality_officio');
+            $table->string('level');
+            $table->string('qualification_type')->nullable();
+            $table->string('attestation_name');
+            $table->date('attestation_date');
+            $table->date('valid_to_date')->nullable();
+            $table->string('certificate_number');
+            $table->morphs('specialityable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('specialities');
+    }
+};

--- a/database/migrations/install/2025_12_10_000040_create_science_degrees_table.php
+++ b/database/migrations/install/2025_12_10_000040_create_science_degrees_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+            Schema::create('science_degrees', function (Blueprint $table) {
+                $table->id();
+                $table->string('country');
+                $table->string('city');
+                $table->string('institution_name');
+                $table->string('degree');
+                $table->string('diploma_number');
+                $table->string('speciality');
+                $table->date('issued_date')->nullable();
+                // default index name is too long for mysql
+                $table->morphs('science_degreeable', 'sd_type_sd_id_index');
+                $table->timestamps();
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('science_degrees');
+    }
+};

--- a/database/migrations/install/2025_12_10_000042_create_addresses_table.php
+++ b/database/migrations/install/2025_12_10_000042_create_addresses_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('addresses', function (Blueprint $table) {
+            $table->id();
+            $table->string('type')->comment('Dictionary ADDRESS_TYPE');
+            $table->string('country')->comment('Dictionary COUNTRY');
+            $table->string('area')->comment('one of Ukrainian area');
+            $table->string('region')->nullable()->comment('district of area');
+            $table->string('settlement')->comment('city name');
+            $table->string('settlement_type')->comment('Dictionary SETTLEMENT_TYPE - type of settlement as city/town/village etc');
+            $table->string('settlement_id')->comment('settlement identification from uaadresses');
+            $table->string('street_type')->nullable()->comment('Dictionary STREET_TYPE - type of street as street/road/line etc');
+            $table->string('street')->nullable()->comment('street name');
+            $table->string('building')->nullable()->comment('number of building');
+            $table->string('apartment')->nullable()->comment('number of apartment');
+            $table->string('zip')->nullable()->comment('system of postal codes');
+            $table->morphs('addressable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('addresses');
+    }
+};

--- a/database/migrations/install/2025_12_10_000044_create_person_requests_table.php
+++ b/database/migrations/install/2025_12_10_000044_create_person_requests_table.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('person_requests', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->nullable();
+            $table->enum('status', ['APPLICATION', 'NEW', 'APPROVED', 'SIGNED', 'REJECTED', 'CANCELLED']);
+            $table->foreignId('person_id')->nullable()->constrained('persons');
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('second_name')->nullable();
+            $table->date('birth_date');
+            $table->string('birth_country');
+            $table->string('birth_settlement');
+            $table->enum('gender', ['MALE', 'FEMALE']);
+            $table->string('email')->unique()->nullable();
+            $table->boolean('no_tax_id');
+            $table->string('tax_id')->nullable();
+            $table->string('secret');
+            $table->string('unzr')->nullable()->comment('the record number in the demographic register');
+            $table->jsonb('emergency_contact');
+            $table->boolean('patient_signed')->default(false)->comment("Person's evidence of sign the person request");
+            $table->boolean('process_disclosure_data_consent')->default(true)->comment("Person's evidence of information about consent to data disclosure");
+            $table->string('authorize_with')->nullable()->comment("identifier of person's auth method");
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('person_requests');
+    }
+};

--- a/database/migrations/install/2025_12_10_000046_create_authentication_methods_table.php
+++ b/database/migrations/install/2025_12_10_000046_create_authentication_methods_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('authentication_methods', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique()->nullable();
+            $table->enum('type', ['THIRD_PERSON', 'OTP', 'OFFLINE', 'NA']);
+            $table->string('phone_number')->nullable();
+            $table->string('value')->nullable();
+            $table->string('alias')->nullable();
+            // default index name is too long for mysql
+            $table->morphs('authenticatable', 'am_type_am_id_index');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('authentication_methods');
+    }
+};

--- a/database/migrations/install/2025_12_10_000048_create_confidant_persons_table.php
+++ b/database/migrations/install/2025_12_10_000048_create_confidant_persons_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('confidant_persons', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('person_id')->nullable()->constrained('persons');
+            $table->foreignId('person_request_id')->nullable()->constrained();
+            $table->jsonb('documents_relationship');
+            $table->string('person_uuid');
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('second_name')->nullable();
+            $table->enum('gender', ['MALE', 'FEMALE']);
+            $table->date('birth_date');
+            $table->string('birth_country');
+            $table->string('birth_settlement');
+            $table->string('tax_id')->nullable();
+            $table->string('birth_certificate')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('confidant_persons');
+    }
+};

--- a/database/migrations/install/2025_12_10_000050_create_icd_10_table.php
+++ b/database/migrations/install/2025_12_10_000050_create_icd_10_table.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types = 1);
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    protected const int CHUNK_SIZE = 10000;
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('icd_10', static function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->index();
+            $table->string('description', 500)->index();
+            $table->boolean('is_active');
+            $table->jsonb('child_values');
+            $table->timestamps();
+        });
+
+        try {
+            $this->setData();
+        } catch (Exception $error) {
+            $this->down();
+
+            throw $error;
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('icd_10');
+    }
+
+    /**
+     * Populate the ICD-10 (InternationalClassification of Diseases, 10th Revision) table with initial data.
+     *
+     * @return void
+     */
+    protected function setData(): void
+    {
+        $dictionary = dictionary()->getLargeDictionary('eHealth/ICD10_AM/condition_codes')['eHealth/ICD10_AM/condition_codes'];
+
+        $data = [];
+
+        foreach ($dictionary as $key => $value) {
+            $data[] = [
+                'code' => $key,
+                'description' => $value['description'],
+                'is_active' => $value['is_active'],
+                'child_values' => json_encode($value['child_values'], JSON_THROW_ON_ERROR),
+                'created_at' => now(),
+                'updated_at' => now()
+            ];
+        }
+
+        // Clear an old table before inserting new data
+        DB::table('icd_10')->truncate();
+
+        // Insert data by chunks
+        $chunks = array_chunk($data, self::CHUNK_SIZE);
+
+        foreach ($chunks as $chunk) {
+            DB::table('icd_10')->insert($chunk);
+        }
+    }
+};

--- a/database/migrations/install/2025_12_10_000052_create_codings_table.php
+++ b/database/migrations/install/2025_12_10_000052_create_codings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('codings', static function (Blueprint $table) {
+            $table->id();
+            $table->string('system')->index();
+            $table->string('code')->index();
+            $table->nullableMorphs('codeable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('codings');
+    }
+};

--- a/database/migrations/install/2025_12_10_000054_create_codeable_concepts_table.php
+++ b/database/migrations/install/2025_12_10_000054_create_codeable_concepts_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('codeable_concepts', static function (Blueprint $table) {
+            $table->id();
+            $table->string('text')->nullable();
+            $table->nullableMorphs('codeable_conceptable', 'cc_morph');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('codeable_concepts');
+    }
+};

--- a/database/migrations/install/2025_12_10_000056_create_identifiers_table.php
+++ b/database/migrations/install/2025_12_10_000056_create_identifiers_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('identifiers', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid('value')->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('identifiers');
+    }
+};

--- a/database/migrations/install/2025_12_10_000058_create_encounters_table.php
+++ b/database/migrations/install/2025_12_10_000058_create_encounters_table.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('encounters', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('person_id')->constrained('persons');
+            $table->uuid()->unique();
+            $table->enum('status', ['entered_in_error', 'finished']);
+            $table->foreignId('visit_id')->constrained('identifiers');
+            $table->foreignId('episode_id')->constrained('identifiers');
+            $table->foreignId('class_id')->constrained('codings');
+            $table->foreignId('type_id')->constrained('codeable_concepts');
+            $table->foreignId('priority_id')->nullable()->constrained('codeable_concepts');
+            $table->foreignId('performer_id')->constrained('identifiers');
+            $table->foreignId('division_id')->nullable()->constrained('identifiers');
+            $table->timestamps();
+        });
+
+        Schema::create('encounter_reasons', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('encounter_id')->constrained('encounters')->cascadeOnDelete();
+            $table->foreignId('codeable_concept_id')->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('encounter_diagnoses', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('encounter_id')->constrained('encounters')->cascadeOnDelete();
+            $table->foreignId('condition_id')->constrained('identifiers')->cascadeOnDelete();
+            $table->foreignId('role_id')->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->integer('rank')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('encounter_actions', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('encounter_id')->constrained('encounters')->cascadeOnDelete();
+            $table->foreignId('codeable_concept_id')->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('encounter_actions');
+
+        Schema::dropIfExists('encounter_diagnoses');
+
+        Schema::dropIfExists('encounter_reasons');
+
+        Schema::dropIfExists('encounters');
+    }
+};

--- a/database/migrations/install/2025_12_10_000060_create_episodes_table.php
+++ b/database/migrations/install/2025_12_10_000060_create_episodes_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('episodes', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid();
+            $table->foreignId('encounter_id')->nullable()->constrained('encounters');
+            $table->foreignId('episode_type_id')->constrained('codings');
+            $table->enum('status', ['active', 'closed', 'entered_in_error']);
+            $table->string('name');
+            $table->foreignId('managing_organization_id')->constrained('identifiers');
+            $table->foreignId('care_manager_id')->constrained('identifiers');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('episodes');
+    }
+};

--- a/database/migrations/install/2025_12_10_000062_create_conditions_table.php
+++ b/database/migrations/install/2025_12_10_000062_create_conditions_table.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('conditions', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique();
+            $table->foreignId('encounter_id')->constrained('encounters');
+            $table->boolean('primary_source');
+            $table->foreignId('asserter_id')->nullable()->constrained('identifiers');
+            $table->foreignId('report_origin_id')->nullable()->constrained('codeable_concepts');
+            $table->foreignId('context_id')->constrained('identifiers');
+            $table->foreignId('code_id')->constrained('codeable_concepts');
+            $table->enum('clinical_status', ['active', 'finished', 'recurrence', 'remission', 'resolved']);
+            $table->enum('verification_status', ['confirmed', 'differential', 'entered_in_error', 'provisional', 'refuted']);
+            $table->foreignId('severity_id')->nullable()->constrained('codeable_concepts');
+            $table->timestamp('onset_date');
+            $table->timestamp('asserted_date')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('condition_evidences', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('condition_id')->constrained('conditions')->cascadeOnDelete();
+            $table->foreignId('codes_id')->nullable()->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->foreignId('details_id')->nullable()->constrained('identifiers')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('condition_evidences');
+
+        Schema::dropIfExists('conditions');
+    }
+};

--- a/database/migrations/install/2025_12_10_000064_create_healthcare_services_table.php
+++ b/database/migrations/install/2025_12_10_000064_create_healthcare_services_table.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Status;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('healthcare_services', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique()->nullable();
+            $table->foreignId('division_id')->constrained()->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('legal_entity_id')->constrained();
+            $table->string('speciality_type')->nullable();
+            $table->string('providing_condition')->nullable();
+            $table->string('license_id')->nullable();
+            $table->enum('status', Status::only(['DRAFT', 'ACTIVE', 'INACTIVE']));
+            $table->foreignId('category_id')->constrained('codeable_concepts');
+            $table->foreignId('type_id')->nullable()->constrained('codeable_concepts');
+            $table->text('comment')->nullable();
+            $table->jsonb('coverage_area')->nullable();
+            $table->jsonb('available_time')->nullable();
+            $table->jsonb('not_available')->nullable();
+            $table->boolean('is_active')->default(false);
+            $table->jsonb('licensed_healthcare_service')->nullable();
+            $table->date('ehealth_inserted_at')->nullable();
+            $table->string('ehealth_inserted_by')->nullable();
+            $table->date('ehealth_updated_at')->nullable();
+            $table->string('ehealth_updated_by')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('healthcare_services');
+    }
+};

--- a/database/migrations/install/2025_12_10_000066_create_periods_table.php
+++ b/database/migrations/install/2025_12_10_000066_create_periods_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('periods', static function (Blueprint $table) {
+            $table->id();
+            $table->timestamp('start');
+            $table->timestamp('end')->nullable();
+            $table->morphs('periodable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('periods');
+    }
+};

--- a/database/migrations/install/2025_12_10_000068_create_immunizations_table.php
+++ b/database/migrations/install/2025_12_10_000068_create_immunizations_table.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('immunizations', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique();
+            $table->foreignId('encounter_id')->constrained('encounters');
+            $table->enum('status', ['completed', 'entered_in_error']);
+            $table->boolean('not_given');
+            $table->foreignId('vaccine_code_id')->constrained('codeable_concepts');
+            $table->foreignId('context_id')->constrained('identifiers');
+            $table->timestamp('date');
+            $table->boolean('primary_source');
+            $table->foreignId('performer_id')->nullable()->constrained('identifiers');
+            $table->foreignId('report_origin_id')->nullable()->constrained('codeable_concepts');
+            $table->string('manufacturer')->nullable();
+            $table->string('lot_number')->nullable();
+            $table->date('expiration_date')->nullable();
+            $table->foreignId('site_id')->nullable()->constrained('codeable_concepts');
+            $table->foreignId('route_id')->nullable()->constrained('codeable_concepts');
+            $table->timestamps();
+        });
+
+        Schema::create('immunization_dose_quantities', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('immunization_id')->constrained('immunizations')->cascadeOnDelete();
+            $table->integer('value');
+            $table->string('comparator')->nullable();
+            $table->enum('unit', ['MG', 'MKG', 'ML'])->nullable();
+            $table->string('system')->nullable();
+            $table->string('code')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('immunization_explanations', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('immunization_id')->constrained('immunizations')->cascadeOnDelete();
+            $table->foreignId('reasons_id')->nullable()->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->foreignId('reasons_not_given_id')->nullable()->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('immunization_vaccination_protocols', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('immunization_id')->constrained('immunizations')->cascadeOnDelete();
+            $table->integer('dose_sequence')->nullable();
+            $table->string('description')->nullable();
+            $table->foreignId('authority_id')->nullable()->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->string('series')->nullable();
+            $table->integer('series_doses')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('immunization_vaccination_protocol_target_diseases', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('vaccination_protocol_id')
+                ->constrained('immunization_vaccination_protocols', 'id', 'fk_ivptd_vaccination_protocol_id')
+                ->cascadeOnDelete();
+            $table->foreignId('codeable_concept_id')
+                ->nullable()
+                ->constrained('codeable_concepts', 'id', 'fk_ivptd_codeable_concept')
+                ->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('immunization_vaccination_protocol_target_diseases');
+
+        Schema::dropIfExists('immunization_vaccination_protocols');
+
+        Schema::dropIfExists('immunization_explanations');
+
+        Schema::dropIfExists('immunization_dose_quantities');
+
+        Schema::dropIfExists('immunizations');
+    }
+};

--- a/database/migrations/install/2025_12_10_000070_create_revisions_table.php
+++ b/database/migrations/install/2025_12_10_000070_create_revisions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Employee\RevisionStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('revisions', static function (Blueprint $table) {
+            $table->id();
+            $table->json('data');
+            $table->jsonb('ehealth_response')->nullable();
+            $table->enum('status', array_column(RevisionStatus::cases(), 'value'))->default(RevisionStatus::PENDING->value);
+            $table->morphs('revisionable');
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('revisions');
+    }
+};

--- a/database/migrations/install/2025_12_10_000072_create_quantities_table.php
+++ b/database/migrations/install/2025_12_10_000072_create_quantities_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('quantities', static function (Blueprint $table) {
+            $table->id();
+            $table->decimal('value')->comment('Numerical value (with implicit precision)');
+            $table->enum('comparator', ['<', '<=', '>=', '>', '='])->nullable()->comment('ad - how to understand the value');
+            $table->string('unit')->nullable()->comment('Unit from eHealth/ucum/units');
+            $table->string('system')->nullable()->comment('dictionary - eHealth/ucum/units');
+            $table->string('code')->nullable()->comment('Code from eHealth/ucum/units');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('quantities');
+    }
+};

--- a/database/migrations/install/2025_12_10_000074_create_observations_table.php
+++ b/database/migrations/install/2025_12_10_000074_create_observations_table.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('observations', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique();
+            $table->foreignId('encounter_id')->nullable()->constrained('encounters');
+            $table->enum('status', ['valid', 'entered_in_error'])->comment('dictionary - eHealth/observation_statuses');
+            $table->foreignId('diagnostic_report_id')->nullable()->constrained('identifiers');
+            $table->foreignId('code_id')->constrained('codeable_concepts');
+            $table->timestamp('effective_date_time')->nullable();
+            $table->timestamp('issued');
+            $table->boolean('primary_source');
+            $table->foreignId('performer_id')->nullable()->constrained('identifiers');
+            $table->foreignId('report_origin_id')->nullable()->constrained('codeable_concepts');
+            $table->foreignId('interpretation_id')->nullable()->constrained('codeable_concepts');
+            $table->text('comment')->nullable();
+            $table->foreignId('body_site_id')->nullable()->constrained('codeable_concepts');
+            $table->foreignId('method_id')->nullable()->constrained('codeable_concepts');
+            $table->foreignId('value_quantity_id')->nullable()->constrained('quantities');
+            $table->foreignId('value_codeable_concept_id')->nullable()->constrained('codeable_concepts');
+            $table->string('value_string')->nullable();
+            $table->boolean('value_boolean')->nullable();
+            $table->timestamp('value_date_time')->nullable();
+            $table->foreignId('reaction_on_id')->nullable()->constrained('identifiers');
+            $table->foreignId('context_id')->nullable()->constrained('identifiers');
+            $table->timestamps();
+        });
+
+        Schema::create('observation_categories', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('observation_id')->constrained('observations')->cascadeOnDelete();
+            $table->foreignId('codeable_concept_id')->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('observation_components', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('observation_id')->constrained('observations')->cascadeOnDelete();
+            $table->foreignId('codeable_concept_id')->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->foreignId('interpretation_id')->nullable()->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('observation_components');
+
+        Schema::dropIfExists('observation_categories');
+
+        Schema::dropIfExists('observations');
+    }
+};

--- a/database/migrations/install/2025_12_10_000076_create_diagnostic_reports_table.php
+++ b/database/migrations/install/2025_12_10_000076_create_diagnostic_reports_table.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('diagnostic_reports', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique();
+            $table->foreignId('encounter_internal_id')->nullable()->constrained('encounters');
+            $table->foreignId('based_on_id')->nullable()->constrained('identifiers');
+            $table->enum('status', ['final', 'entered_in_error']);
+            $table->foreignId('code_id')->constrained('identifiers');
+            $table->timestamp('effective_date_time')->nullable();
+            $table->timestamp('issued');
+            $table->text('conclusion')->nullable();
+            $table->foreignId('conclusion_code_id')->nullable()->constrained('codeable_concepts');
+            $table->foreignId('recorded_by_id')->constrained('identifiers');
+            $table->foreignId('encounter_id')->nullable()->constrained('identifiers');
+            $table->boolean('primary_source');
+            $table->foreignId('division_id')->nullable()->constrained('identifiers');
+            $table->foreignId('managing_organization_id')->nullable()->constrained('identifiers');
+            $table->foreignId('report_origin_id')->nullable()->constrained('codeable_concepts');
+            $table->timestamps();
+        });
+
+        Schema::create('diagnostic_report_categories', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('diagnostic_report_id')->constrained('diagnostic_reports')->cascadeOnDelete();
+            $table->foreignId('codeable_concept_id')->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('diagnostic_report_performer', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('diagnostic_report_id')->constrained('diagnostic_reports')->cascadeOnDelete();
+            $table->foreignId('reference_id')->nullable()->constrained('identifiers')->cascadeOnDelete();
+            $table->string('text')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('diagnostic_report_results_interpreter', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('diagnostic_report_id')
+                ->constrained('diagnostic_reports', 'id', 'fk_drri_diagnostic_report_id')
+                ->cascadeOnDelete();
+            $table->foreignId('reference_id')->nullable()->constrained('identifiers')->cascadeOnDelete();
+            $table->string('text')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('diagnostic_report_results_interpreter');
+
+        Schema::dropIfExists('diagnostic_report_performer');
+
+        Schema::dropIfExists('diagnostic_report_categories');
+
+        Schema::dropIfExists('diagnostic_reports');
+    }
+};

--- a/database/migrations/install/2025_12_10_000078_create_paper_referrals_table.php
+++ b/database/migrations/install/2025_12_10_000078_create_paper_referrals_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('paper_referrals', static function (Blueprint $table) {
+            $table->id();
+            $table->string('requisition')->nullable();
+            $table->string('requester_legal_entity_name')->nullable();
+            $table->string('requester_legal_entity_edrpou');
+            $table->string('requester_employee_name');
+            $table->string('service_request_date');
+            $table->text('note')->nullable();
+            $table->morphs('paper_referralable', 'ppr_morph');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('paper_referrals');
+    }
+};

--- a/database/migrations/install/2025_12_10_000080_create_procedures_table.php
+++ b/database/migrations/install/2025_12_10_000080_create_procedures_table.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('procedures', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique();
+            $table->foreignId('encounter_internal_id')->nullable()->constrained('encounters');
+            $table->enum('status', ['completed', 'entered_in_error']);
+            $table->foreignId('based_on_id')->nullable()->constrained('identifiers');
+            $table->foreignId('code_id')->constrained('identifiers');
+            $table->foreignId('encounter_id')->nullable()->constrained('identifiers');
+            $table->foreignId('recorded_by_id')->constrained('identifiers');
+            $table->boolean('primary_source');
+            $table->foreignId('performer_id')->nullable()->constrained('identifiers');
+            $table->foreignId('report_origin_id')->nullable()->constrained('codeable_concepts');
+            $table->foreignId('division_id')->nullable()->constrained('identifiers');
+            $table->foreignId('managing_organization_id')->nullable()->constrained('identifiers');
+            $table->foreignId('outcome_id')->nullable()->constrained('codeable_concepts');
+            $table->text('note')->nullable()->comment('Any other notes and comments about the procedure.');
+            $table->foreignId('category_id')->nullable()->constrained('codeable_concepts');
+            $table->timestamps();
+        });
+
+        Schema::create('procedure_reason_references', static function (Blueprint $table) {
+            $table->comment('The justification of why the procedure was performed.');
+            $table->id();
+            $table->foreignId('procedure_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('identifier_id')->constrained('identifiers')->cascadeOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('procedure_complication_details', static function (Blueprint $table) {
+            $table->comment('Any complications that occurred during the procedure, or in the immediate post-performance period. Could be filled only for procedure in encounter package and only with reference to condition from same encounter');
+            $table->id();
+            $table->foreignId('procedure_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('identifier_id')->constrained('identifiers')->cascadeOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('procedure_used_codes', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('procedure_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('codeable_concept_id')->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('procedure_used_codes');
+
+        Schema::dropIfExists('procedure_complication_details');
+
+        Schema::dropIfExists('procedure_reason_references');
+
+        Schema::dropIfExists('procedures');
+    }
+};

--- a/database/migrations/install/2025_12_10_000082_create_clinical_impressions_table.php
+++ b/database/migrations/install/2025_12_10_000082_create_clinical_impressions_table.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('clinical_impressions', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique();
+            $table->foreignId('encounter_internal_id')->constrained('encounters');
+            $table->enum('status', ['completed', 'entered_in_error']);
+            $table->text('description')->nullable()->comment('Some description of the clinical impression');
+            $table->foreignId('code_id')->constrained('codeable_concepts');
+            $table->foreignId('encounter_id')->constrained('identifiers');
+            $table->foreignId('assessor_id')->comment('author of the clinical impression')->constrained('identifiers');
+            $table->foreignId('previous_id')->nullable()->constrained('identifiers');
+            $table->text('summary')->nullable()->comment('Some summary');
+            $table->text('note')->nullable()->comment('Some note');
+            $table->timestamps();
+        });
+
+        Schema::create('clinical_impression_problems', static function (Blueprint $table) {
+            $table->comment('relevant impressions of patient state');
+            $table->id();
+            $table->foreignId('clinical_impression_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('identifier_id')->constrained('identifiers')->cascadeOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('clinical_impression_findings', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('clinical_impression_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('item_reference_id')->constrained('identifiers')->cascadeOnDelete();
+            $table->text('basis')->nullable()->comment('Some basis');
+            $table->timestamps();
+        });
+
+        Schema::create('clinical_impression_supporting_info', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('clinical_impression_id')
+                ->constrained('clinical_impressions', 'id', 'fk_cisi_clinical_impression_id')
+                ->cascadeOnDelete();
+            $table->foreignId('identifier_id')->constrained('identifiers')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('clinical_impression_supporting_info');
+
+        Schema::dropIfExists('clinical_impression_findings');
+
+        Schema::dropIfExists('clinical_impression_problems');
+
+        Schema::dropIfExists('clinical_impressions');
+    }
+};

--- a/database/migrations/install/2025_12_10_000084_create_notifications_table.php
+++ b/database/migrations/install/2025_12_10_000084_create_notifications_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', static function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/database/migrations/install/2025_12_10_000086_create_job_batches_table.php
+++ b/database/migrations/install/2025_12_10_000086_create_job_batches_table.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('job_batches', function (Blueprint $table) {
+            $table->string('id')->primary();
+
+            // Add foreign key constraint to legal_entities table
+            $table->foreignId('legal_entity_id')->nullable()->constrained()->nullOnDelete();
+
+            // Add legal_entity_id field to track which legal entity the batch belongs to
+            // $table->unsignedBigInteger('legal_entity_id')->nullable()->after('options');
+
+            // Add foreign key constraint to legal_entities table
+            // $table->foreign('legal_entity_id')
+            //       ->references('id')
+            //       ->on('legal_entities')
+            //       ->onDelete('set null'); // Set to null if legal entity is deleted
+
+            $table->string('name');
+            $table->integer('total_jobs');
+            $table->integer('pending_jobs');
+            $table->integer('failed_jobs');
+            $table->longText('failed_job_ids');
+            $table->mediumText('options')->nullable();
+            $table->integer('cancelled_at')->nullable();
+            $table->integer('created_at');
+            $table->integer('finished_at')->nullable();
+
+            // Add index for better query performance
+            $table->index(['legal_entity_id', 'created_at'], 'idx_job_batches_legal_entity_created');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('job_batches', function (Blueprint $table) {
+            // Drop foreign key constraint first
+            $table->dropForeign(['legal_entity_id']);
+
+            // Drop index
+            $table->dropIndex('idx_job_batches_legal_entity_created');
+        });
+
+        Schema::dropIfExists('job_batches');
+    }
+};

--- a/database/migrations/install/2025_12_10_000088_create_users_table.php
+++ b/database/migrations/install/2025_12_10_000088_create_users_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('party_id')->nullable()->constrained('parties')->onDelete('set null');
+            $table->uuid()->nullable()->unique();
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+
+            $table->text('two_factor_secret')->nullable();
+            $table->text('two_factor_recovery_codes')->nullable();
+            $table->timestamp('two_factor_confirmed_at')->nullable();
+
+            $table->foreignId('current_team_id')->nullable();
+            $table->string('profile_photo_path', 2048)->nullable();
+            $table->jsonb('settings')->nullable();
+            $table->jsonb('priv_settings')->nullable();
+            $table->boolean('is_blocked')->nullable();
+            $table->string('block_reason')->nullable();
+            $table->foreignId('person_id')->nullable()->constrained('persons')->onDelete('set null');
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/database/migrations/install/2025_12_10_000090_create_employees_table.php
+++ b/database/migrations/install/2025_12_10_000090_create_employees_table.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\JobStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employees', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique();
+            $table->uuid('division_uuid')->nullable();
+            $table->uuid('legal_entity_uuid')->nullable();
+            $table->string('position');
+            $table->date('start_date');
+            $table->date('end_date')->nullable();
+            $table->string('employee_type');
+            $table->date('inserted_at')->nullable();
+            $table->string('status')->nullable();
+            $table->enum('sync_status', JobStatus::values())->nullable();
+            $table->boolean('is_active')->default(false);
+            $table->foreignId('legal_entity_id')->nullable()->constrained('legal_entities')->onDelete('cascade');
+            $table->foreignId('division_id')->nullable()->constrained('divisions')->onDelete('cascade');
+            $table->foreignId('user_id')->nullable()->constrained('users')->onDelete('cascade');
+            $table->foreignId('party_id')->nullable()->constrained('parties')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employees');
+    }
+};

--- a/database/migrations/install/2025_12_10_000092_create_declaration_requests_table.php
+++ b/database/migrations/install/2025_12_10_000092_create_declaration_requests_table.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Declaration\RequestStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('declaration_requests', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique()->nullable();
+            $table->string('authorize_with')->nullable()->comment("identifier of person's auth method");
+            $table->jsonb('data_to_be_signed')->nullable();
+            $table->string('channel')->nullable();
+            $table->integer('current_declaration_count')->nullable();
+            $table->string('parent_declaration_id')
+                ->nullable()
+                ->comment('identifier of parent declaration in reorganized legal entity');
+            $table->string('declaration_number')->nullable();
+            $table->foreignId('division_id')
+                ->comment('Registered Medical Service Provider Division identifier.')
+                ->constrained();
+            $table->foreignId('employee_id')
+                ->comment('Employee ID with type=DOCTOR selected from available Employees as a third contract party.')
+                ->constrained();
+            $table->date('start_date')->nullable();
+            $table->date('end_date')->nullable();
+            $table->foreignId('legal_entity_id')->constrained();
+            $table->foreignId('person_id')->constrained('persons');
+            // https://e-health-ua.atlassian.net/wiki/spaces/ESOZ/pages/18426003727/declaration_request_statuses
+            $table->enum(
+                'status',
+                array_map(static fn (RequestStatus $status) => $status->value, RequestStatus::cases())
+            )
+                ->nullable();
+            // https://e-health-ua.atlassian.net/wiki/spaces/ESOZ/pages/18426758317/declaration_request_status_reason
+            $table->enum('status_reason', [
+                'auto_approve',
+                'doctor_approval_needed',
+                'doctor_approved_over_limit',
+                'doctor_confirmed',
+                'doctor_reject',
+                'doctor_rejected_over_limit',
+                'doctor_signed',
+                'patient_reject',
+                'request_cancelled',
+                'request_overdue'
+            ])->nullable();
+            $table->integer('system_declaration_limit')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('declaration_requests');
+    }
+};

--- a/database/migrations/install/2025_12_10_000094_create_employee_requests_table.php
+++ b/database/migrations/install/2025_12_10_000094_create_employee_requests_table.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Employee\RequestStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employee_requests', function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->nullable();
+            $table->uuid('division_uuid')->nullable();
+            $table->uuid('legal_entity_uuid')->nullable();
+            $table->string('position');
+            $table->date('start_date');
+            $table->date('end_date')->nullable();
+            $table->string('employee_type');
+            $table->string('email');
+            $table->date('inserted_at')->nullable();
+            $table->enum('status', array_column(RequestStatus::cases(), 'value'))->default(RequestStatus::NEW->value)->nullable();
+            $table->foreignId('employee_id')->nullable()->constrained('employees')->onDelete('cascade');
+            $table->foreignId('legal_entity_id')->nullable()->constrained('legal_entities')->onDelete('cascade');
+            $table->foreignId('division_id')->nullable()->constrained('divisions')->onDelete('cascade');
+            $table->foreignId('user_id')->nullable()->constrained('users')->onDelete('cascade');
+            $table->foreignId('party_id')->nullable()->constrained('parties')->onDelete('cascade');
+            $table->timestamp('applied_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_requests');
+    }
+};

--- a/database/migrations/install/2025_12_10_000096_create_contract_requests_table.php
+++ b/database/migrations/install/2025_12_10_000096_create_contract_requests_table.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Contract\Status;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('contract_requests', static function (Blueprint $table) {
+            $table->id();
+
+            // eHealth ID (assigned after initialization)
+            $table->uuid('uuid')->nullable()->unique();
+
+            // Relations
+            $table->uuid('contractor_legal_entity_id')->index();
+            $table->uuid('contractor_owner_id')->index();
+            $table->uuid('previous_request_id')->nullable()->index();
+            $table->uuid('parent_contract_id')->nullable()->index();
+
+            // Basic fields
+            $table->string('contractor_base')->nullable();
+            $table->string('contract_number')->nullable();
+            $table->string('id_form')->nullable();
+            $table->string('status')->default('NEW')->index();
+            $table->text('status_reason')->nullable();
+            $table->string('type')->nullable(); // CAPITATION / REIMBURSEMENT
+
+            // JSONB fields for detailed structures
+            $table->jsonb('contractor_payment_details')->nullable();
+            $table->jsonb('external_contractors')->nullable();
+            $table->jsonb('contractor_employee_divisions')->nullable();
+
+            // Raw response data storage
+            $table->jsonb('data')->nullable();
+
+            // Dates
+            $table->date('start_date')->nullable();
+            $table->date('end_date')->nullable();
+
+            // NHS (NSZU) side data
+            $table->uuid('nhs_legal_entity_id')->nullable();
+            $table->uuid('nhs_signer_id')->nullable();
+            $table->string('nhs_signer_base')->nullable();
+            $table->double('nhs_contract_price')->nullable();
+            $table->string('nhs_payment_method')->nullable();
+            $table->date('nhs_signed_date')->nullable();
+
+            // Metadata
+            $table->uuid('ehealth_inserted_by')->nullable();
+            $table->timestamp('ehealth_inserted_at')->nullable();
+            $table->boolean('contractor_signed')->default(false);
+
+            $table->timestamps();
+        });
+
+        Schema::create('contract_request_division', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('contract_request_id')->constrained();
+            $table->foreignId('division_id')->constrained();
+            $table->timestamps();
+        });
+
+        Schema::create('medical_programs', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid();
+            $table->foreignId('contract_request_id');
+            $table->uuid('ehealth_inserted_by')->nullable();
+            $table->uuid('ehealth_updated_by')->nullable();
+            $table->timestamp('ehealth_inserted_at')->nullable();
+            $table->timestamp('ehealth_updated_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('contract_requests');
+    }
+};

--- a/database/migrations/install/2025_12_10_000098_create_declarations_table.php
+++ b/database/migrations/install/2025_12_10_000098_create_declarations_table.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Declaration\Status;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('declarations', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid();
+            $table->string('declaration_number')->unique();
+            $table->foreignId('declaration_request_id')->constrained();
+            $table->foreignId('division_id')->constrained();
+            $table->foreignId('employee_id')->constrained();
+            $table->foreignId('legal_entity_id')->constrained();
+            $table->foreignId('person_id')->constrained('persons');
+            $table->date('end_date');
+            $table->dateTime('inserted_at');
+            $table->boolean('is_active');
+            $table->string('reason')->nullable();
+            $table->string('reason_description')->nullable();
+            $table->dateTime('signed_at');
+            $table->date('start_date');
+            $table->enum('status', Status::values());
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('declarations');
+    }
+};

--- a/database/migrations/install/2025_12_10_000100_create_employee_roles_table.php
+++ b/database/migrations/install/2025_12_10_000100_create_employee_roles_table.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Status;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employee_roles', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique();
+            $table->foreignId('employee_id')->constrained();
+            $table->foreignId('healthcare_service_id')->constrained();
+            $table->dateTimeTz('start_date');
+            $table->dateTimeTz('end_date')->nullable();
+            $table->enum('status', [Status::ACTIVE, Status::INACTIVE]);
+            $table->boolean('is_active');
+            $table->dateTimeTz('ehealth_inserted_at');
+            $table->string('ehealth_inserted_by');
+            $table->dateTimeTz('ehealth_updated_at');
+            $table->string('ehealth_updated_by');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_roles');
+    }
+};

--- a/database/migrations/install/2025_12_10_000102_create_equipments_table.php
+++ b/database/migrations/install/2025_12_10_000102_create_equipments_table.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Equipment\{AvailabilityStatus, Status, Type};
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('equipments', static function (Blueprint $table) {
+            $table->id();
+            $table->uuid()->unique()->nullable();
+            $table->foreignId('legal_entity_id')->nullable()->constrained();
+            $table->foreignId('division_id')->nullable()->constrained();
+            $table->foreignId('parent_id')->nullable()->constrained('equipments')->nullOnDelete();
+            $table->foreignId('recorder')->nullable()->constrained('employees');
+            $table->uuid('device_definition_id')->comment('Reference to device definition')->nullable(); // separate table
+            $table->string('type');
+            $table->string('serial_number')->nullable();
+            $table->enum('status', Status::values());
+            $table->enum('availability_status', AvailabilityStatus::values());
+            $table->string('manufacturer')->nullable();
+            $table->date('manufacture_date')->nullable();
+            $table->string('model_number')->nullable();
+            $table->string('inventory_number')->nullable();
+            $table->string('lot_number')->nullable();
+            $table->date('expiration_date')->nullable();
+            $table->text('note')->nullable();
+            $table->jsonb('properties')->nullable();
+            $table->enum('error_reason', ['typo'])->nullable(); // https://e-health-ua.atlassian.net/wiki/spaces/ESOZ/pages/18769543191/equipment_status_reasons
+            $table->date('ehealth_inserted_at')->nullable();
+            $table->uuid('ehealth_inserted_by')->nullable();
+            $table->date('ehealth_updated_at')->nullable();
+            $table->uuid('ehealth_updated_by')->nullable();
+
+            // Inventory number must be unique within legal entity if it is set in request.
+            $table->unique(['legal_entity_id', 'inventory_number']);
+            $table->timestamps();
+        });
+
+        Schema::create('equipment_names', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('equipment_id')->constrained('equipments');
+            $table->string('name');
+            $table->enum('type', Type::values());
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('equipment_names');
+        Schema::dropIfExists('equipments');
+    }
+};

--- a/database/migrations/install/2025_12_10_000104_create_migration_backups_table.php
+++ b/database/migrations/install/2025_12_10_000104_create_migration_backups_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('migration_backups', function (Blueprint $table) {
+            $table->id();
+            $table->string('migration', 255)->unique();
+            $table->longText('data')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('migration_backups');
+    }
+};

--- a/database/migrations/update/0_1/2025_12_17_00001_update_legal_entity_types_table.php
+++ b/database/migrations/update/0_1/2025_12_17_00001_update_legal_entity_types_table.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LegalEntity;
+use App\Core\ExtendedMigration;
+
+/**
+ * --- EXAMPLE MIGRATION ---
+ *
+ * This migration removes specific (unused) legal entity types
+ */
+return new class extends ExtendedMigration
+{
+    // Data to be removed
+    protected const array PROCEEDED_TYPES = [
+        ['name' => LegalEntity::TYPE_MIS],
+        ['name' => LegalEntity::TYPE_NHS],
+        ['name' => LegalEntity::TYPE_MSP_PHARMACY],
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $backupData = DB::table('legal_entity_types')
+            ->whereIn('name', array_column(self::PROCEEDED_TYPES, 'name'))
+            ->get()
+            ->toArray();
+
+        // Backup existing data in migration_backups table
+        $this->backup($backupData);
+
+        $this->doUpdate();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        logger('Restoring legal_entity_types from backup');
+
+        // Retrieve backup data from migration_backups table
+        $backupData = $this->restore();
+
+        if ($backupData === null) {
+            logger('No backup data found for legal_entity_type_permissions migration. Skipping restore.');
+
+            return;
+        }
+
+        DB::table('legal_entity_types')->insertOrIgnore($backupData);
+    }
+
+    /**
+     * Set the updated data for the legal_entity_types table.
+     *
+     * @return void
+     */
+    protected function doUpdate(): void
+    {
+            DB::table('legal_entity_types')
+            ->whereIn('name', array_column(self::PROCEEDED_TYPES, 'name'))
+            ->delete();
+    }
+};


### PR DESCRIPTION
This PR concerns to the #610 ISSUE

Що було зроблено:

- створено новий каталог database/migrations/install де знаходяться всі міграції, необхідні при розгортанні програми;
- створено консольну команду install, яка забезпечує початкову ініціалізацію бази даних і заповнення таблиць необхідними даними;
- змерджено міграції job_batches (міграція +її update);
- додано нову таблицю 'migration_backups' де зберігатимуться дані, які змінюються (для відновлення за потреби);
- створено базовий клас ExtendedMigration, від якого мають розширюватись міграції, які виконують бекап/відновлення . Для цього передбачені методи backup()/restore();
- створено новий каталог database/migrations/update де планується розміщувати всі міграції, необхідні при оновленні програми;
- створено консольну команду update, яка забезпечує модифікацію бази даних і заповнення таблиць необхідними даними;
- додано версіонування. Опційний параметр APP_VERSION в .env файлі;
- створено тестовий каталог 0_1 (поточна версія) з тестовою міграцією в якості прикладу роботи з оновленням БД.

**ПРИМІТКА:** 
- для встановлення системи має використовуватись команда `php artisan install --clear --wipe --key`; 
- для накладання модифікацій має використовуватись команда `php artisan update --clear` - (використовуватиме поточну версію). Якщо потрібно зробити модифікацію певної версії програми, можна використовувати ключ '--ver'. Наприклад: `php artisan update --clear --ver=0.2`;
- для відміни зроблених (останніх) змін має використовуватись команда: `php artisan update --clear --rollback`. 

ВАЖЛИВО:
Перед роботою з командами потрібно оновити autoload: `composer dump-autoload -o`