### PR TITLE
#526: fix flash messages overlapping on the login pages

### DIFF
--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -3,8 +3,6 @@
 @endphp
 
 <div class="fragment">
-    <x-messages />
-
     <x-authentication-card>
 
             <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-6">

--- a/resources/views/livewire/auth/login-layout.blade.php
+++ b/resources/views/livewire/auth/login-layout.blade.php
@@ -1,5 +1,4 @@
 <div class="fragment">
-    <x-messages/>
     <x-authentication-card>
 
         <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -4,8 +4,6 @@
 @endphp
 
 <div class="fragment">
-    <x-messages />
-
     <x-authentication-card>
         <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
             {{ __('forms.new_password') }}

--- a/resources/views/livewire/auth/verify-email.blade.php
+++ b/resources/views/livewire/auth/verify-email.blade.php
@@ -1,6 +1,4 @@
 <div class="fragment">
-    <x-messages />
-
     <x-authentication-card>
         <h2 class="text-lg font-medium text-gray-900 text-center dark:text-gray-100">
             {{  __('forms.email_confirmation') }}

--- a/resources/views/livewire/components/x-message.blade.php
+++ b/resources/views/livewire/components/x-message.blade.php
@@ -1,6 +1,6 @@
 <div>
     @if(session('error') || session('success') || session('status'))
-        <div class="alert-message flex fixed top-[1.5rem] w-auto z-[100000] right-2"
+        <div class="alert-message flex fixed top-[1.5rem] w-auto z-[99999] right-2"
             wire:key="{{ time() }}"
             x-data="message"
             x-show="showAlertMessage"
@@ -31,7 +31,7 @@
                 type="button"
                 @click="showAlertMessage= false"
                 aria-label="Close"
-                class="absolute -top-2 -right-1 inline-flex items-center justify-center rounded-full border border-red-300 hover:border-2 hover:border-red-400 active:border-red-600 bg-white/90 hover:bg-white drop-shadow-sm shadow-lg text-gray-600 hover:text-gray-800 w-6 h-6 cursor-pointer transition-all"
+                class="absolute -top-2 -right-1 inline-flex items-center justify-center rounded-full border border-red-300 hover:border-2 hover:border-red-400 active:border-red-600 bg-white/90 hover:bg-white drop-shadow-sm shadow-lg text-gray-600 hover:text-gray-800 w-6 h-6 cursor-pointer transition-all z-[100000]"
             >
                 @icon('close', 'w-3.5 h-3.5')
             </button>


### PR DESCRIPTION
This PR concerns to the #536 ISSUE

Що було зроблено:

- після додавання лейауту для сторінки логіну флуш- повідомлення викликались з двох різних компонентів. Пофікшенно