### PR TITLE
#536: fix way to get CIPHER API base url

### DIFF
--- a/app/Classes/Cipher/Request.php
+++ b/app/Classes/Cipher/Request.php
@@ -30,7 +30,10 @@ class Request
      */
     public function sendRequest()
     {
-        $url = env('CIPHER_API_URL') . $this->url;
+        $apiBase = config('cipher.api.domain');
+
+        $url = $apiBase . $this->url;
+
         $response = Http::acceptJson()
             ->withBody($this->params )
             ->{$this->method}($url);


### PR DESCRIPTION
This PR concerns to the #536 ISSUE

Що було зроблено:
- пофікшено баг, який при певних умовах унеможливлював отримання базової адреси API-серверу Сайфер, що призводило до появи помилки: `cURL error 6: Could not resolve host: certificateAuthority (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for certificateAuthority/supported`