### PR TITLE
#610: fix first-run command after migration modification

### DIFF
--- a/app/Console/Commands/Install.php
+++ b/app/Console/Commands/Install.php
@@ -69,7 +69,7 @@ class Install extends MigrationsCommand
         if ($this->options['key']) {
             $this->info('Generating new application key...');
 
-            $this->call('key:generate');
+            $this->call('key:generate',  ['--force' => true]);
         }
     }
 

--- a/database/migrations/install/2025_12_10_000096_create_contract_requests_table.php
+++ b/database/migrations/install/2025_12_10_000096_create_contract_requests_table.php
@@ -58,24 +58,6 @@ return new class extends Migration
 
             $table->timestamps();
         });
-
-        Schema::create('contract_request_division', static function (Blueprint $table) {
-            $table->id();
-            $table->foreignId('contract_request_id')->constrained();
-            $table->foreignId('division_id')->constrained();
-            $table->timestamps();
-        });
-
-        Schema::create('medical_programs', static function (Blueprint $table) {
-            $table->id();
-            $table->uuid();
-            $table->foreignId('contract_request_id');
-            $table->uuid('ehealth_inserted_by')->nullable();
-            $table->uuid('ehealth_updated_by')->nullable();
-            $table->timestamp('ehealth_inserted_at')->nullable();
-            $table->timestamp('ehealth_updated_at')->nullable();
-            $table->timestamps();
-        });
     }
 
     public function down(): void

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,20 +16,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        Artisan::call('cache:clear');
-
-        $this->call([
-            /*
-             * populates permissions and roles tables, see spaties laravel-permissions docs
-             * https://spatie.be/docs/laravel-permission/v6/introduction
-             */
-            LegalEntityTypeSeeder::class,
-            LegalEntityRoleSeeder::class,
-            PermissionsSeeder::class,
-            RolePermissionsSeeder::class,
-            TypePermissionsSeeder::class,
-            LegalEntityTypeAndRoleSeeder::class
-        ]);
 
         if (app()->isLocal()) {
             // Populates following tables legal_entities, users and model has roles with test data

--- a/routes/console.php
+++ b/routes/console.php
@@ -22,9 +22,6 @@ Artisan::command('inspire', function () {
 })->purpose('Display an inspiring quote');
 
 Artisan::command('first-run', function () {
-    $this->call('key:generate');
-    $this->call('migrate');
+    $this->call('install', ['--clear' => true, '--wipe' => true,'--key' => true]);
     $this->call('db:seed', ['--class' => 'DatabaseSeeder']);
-    UpdateICD10TableJob::dispatchSync();
-    //    $this->call('permission:create-role', ['name' => 'Owner']);
 })->purpose('Completes the first run of the application');


### PR DESCRIPTION
This PR concerns to the #610 ISSUE

Що було зроблено:

- команда first-run тепер викликає команду install;
- з сідера залишено лиш додавання тестового закладу;
- синхронізовано міграцію create_contract_requests_table в каталозі install з поточною версією.

**ПРИМІТКА:** для початку роботи з тестовим середовищем тепер достатньо дати команду `php artisan first-run`. Це "дропне" базу даних, заповнить даними базові системні таблиці і додасть тестовий заклад з користувачем.