### PR TITLE
#680_reactive_dictionaries_load_for_employee

### DIFF
--- a/resources/views/livewire/employee/parts/education.blade.php
+++ b/resources/views/livewire/employee/parts/education.blade.php
@@ -3,7 +3,7 @@
               :disabled="$wire.isPositionDataLocked ?? false"
               x-data="{
                   educations: $wire.entangle('form.doctor.educations'),
-                  employeeType: $wire.get('form.employeeType'),
+                  employeeType: $wire.entangle('form.employeeType'),
                   employeeTypeSpecialities: @js($this->employeeTypeSpecialities),
                   employeeTypeDegrees: @js($this->employeeTypeDegrees),
                   openModal: false,

--- a/resources/views/livewire/employee/parts/qualifications.blade.php
+++ b/resources/views/livewire/employee/parts/qualifications.blade.php
@@ -3,7 +3,7 @@
               :disabled="$wire.isPositionDataLocked ?? false"
               x-data="{
                   qualifications: $wire.entangle('form.doctor.qualifications'),
-                  employeeType: $wire.get('form.employeeType'),
+                  employeeType: $wire.entangle('form.employeeType'),
                   employeeTypeSpecialities: @js($this->employeeTypeSpecialities),
                   employeeTypeQualifications: @js($this->employeeTypeQualifications),
                   openModal: false,

--- a/resources/views/livewire/employee/parts/science_degree.blade.php
+++ b/resources/views/livewire/employee/parts/science_degree.blade.php
@@ -3,8 +3,8 @@
               :disabled="$wire.isPositionDataLocked ?? false"
               x-data="{
                   scienceDegree: $wire.entangle('form.doctor.scienceDegree').live,
-                  employeeType: $wire.get('form.employeeType'),
-                  employeeTypeSpecialities: @js($this->employeeTypeSpecialities), // Додано для фільтрації
+                  employeeType: $wire.entangle('form.employeeType'),
+                  employeeTypeSpecialities: @js($this->employeeTypeSpecialities),
                   openModal: false,
                   modalScienceDegree: new ScienceDegree(),
                   isNew: false,

--- a/resources/views/livewire/employee/parts/specialities.blade.php
+++ b/resources/views/livewire/employee/parts/specialities.blade.php
@@ -3,7 +3,7 @@
               :disabled="$wire.isPositionDataLocked ?? false"
               x-data="{
                   specialities: $wire.entangle('form.doctor.specialities'),
-                  employeeType: $wire.get('form.employeeType'),
+                  employeeType: $wire.entangle('form.employeeType'),
                   employeeTypeSpecialities: @js($this->employeeTypeSpecialities),
                   employeeTypeLevels: @js($this->employeeTypeLevels),
                   employeeTypeSpecQualifications: @js($this->employeeTypeSpecQualifications),


### PR DESCRIPTION
фікс багу, коли ми у формі створення співробітника
обираєму одну посаду
а потім змінюємо її, то у залених партіціях, лише 1 раз підтягувались словники із
спеціальностями, освітами і кваліфікаціями.

Тепер динамічно оновлюється і можна міняти посаду, і отримувати актуальні словники.