### PR TITLE
#663: disable sync buttons when synchronization has been started

### DIFF
--- a/app/Classes/eHealth/Api/Dictionary.php
+++ b/app/Classes/eHealth/Api/Dictionary.php
@@ -27,6 +27,6 @@ class Dictionary extends Request
      */
     public function getDictionaries(array $query = []): PromiseInterface|EHealthResponse
     {
-        return $this->get(self::URL, $query);
+        return $this->timeout(300)->get(self::URL, $query);
     }
 }

--- a/app/Classes/eHealth/Api/LegalEntity.php
+++ b/app/Classes/eHealth/Api/LegalEntity.php
@@ -158,9 +158,9 @@ class LegalEntity extends Request
             'website' => "nullable|string",
 
             'ehealth_inserted_at' => 'nullable|date',
-            'ehealth_inserted_by' => 'nullable|uuid',
+            'inserted_by' => 'nullable|uuid',
             'ehealth_updated_at' => 'nullable|date',
-            'ehealth_updated_by' => 'nullable|uuid',
+            'updated_by' => 'nullable|uuid',
 
             'public_offer' => 'nullable|array',
             'public_offer.consent_text' => 'required_with:public_offer|string',
@@ -186,9 +186,7 @@ class LegalEntity extends Request
             $newName = match ($name) {
                 'id' => 'uuid',
                 'inserted_at' => 'ehealth_inserted_at',
-                'inserted_by' => 'ehealth_inserted_by',
                 'updated_at' => 'ehealth_updated_at',
-                'updated_by' => 'ehealth_updated_by',
                 default => $name
             };
 

--- a/app/Core/EHealthJob.php
+++ b/app/Core/EHealthJob.php
@@ -8,6 +8,7 @@ use Throwable;
 use App\Models\User;
 use App\Enums\JobStatus;
 use Illuminate\Bus\Batch;
+use App\Jobs\CompleteSync;
 use App\Models\LegalEntity;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
@@ -114,7 +115,9 @@ abstract class EHealthJob implements ShouldQueue
         echo "Start from user: " . ($this->user ? $this->user->id : 'No user found') . PHP_EOL;
         echo "Legal Entity ID: " . ($this->legalEntity ? $this->legalEntity->id : 'No legal entity found') . PHP_EOL;
 
-        $this->setEntityStatus(JobStatus::PROCESSING);
+        if (static::BATCH_NAME !== CompleteSync::BATCH_NAME) {
+            $this->setEntityStatus(JobStatus::PROCESSING);
+        }
 
         $this->token = Crypt::decryptString($this->batch()->options['token'] ?? '');
 
@@ -136,14 +139,16 @@ abstract class EHealthJob implements ShouldQueue
             return;
         }
 
-        echo "Job COMPLETED: " . static::BATCH_NAME . PHP_EOL;
-
-        $this->setEntityStatus(JobStatus::COMPLETED);
-
         $nextJob = $this->getNextEntityJob();
 
         if ($nextJob !== null) {
-            echo "Scheduling next job: " . $nextJob::BATCH_NAME . PHP_EOL;
+            echo "Scheduling next job: " . $nextJob::BATCH_NAME . " from " . static::BATCH_NAME.  PHP_EOL;
+
+            if ($nextJob::BATCH_NAME === CompleteSync::BATCH_NAME || $nextJob::BATCH_NAME !== static::BATCH_NAME) {
+                echo "Job COMPLETED: " . static::BATCH_NAME . PHP_EOL;
+
+                $this->setEntityStatus(JobStatus::COMPLETED);
+            }
 
             Bus::batch([$nextJob])
                 ->name($nextJob::BATCH_NAME)

--- a/app/Jobs/DeclarationsSync.php
+++ b/app/Jobs/DeclarationsSync.php
@@ -19,7 +19,7 @@ class DeclarationsSync extends EHealthJob
 
     public const string SCOPE_REQUIRED = 'declaration:read';
 
-    public const string ENTITY = LegalEntity::ENTITY_EMPLOYEE;
+    public const string ENTITY = LegalEntity::ENTITY_DECLARATION;
 
     /**
      * Get declarations data from EHealth API

--- a/app/Jobs/EmployeeRequestDetailsUpsert.php
+++ b/app/Jobs/EmployeeRequestDetailsUpsert.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use Throwable;
+use App\Core\Arr;
+use App\Models\User;
 use App\Core\EHealthJob;
 use App\Enums\JobStatus;
 use App\Models\LegalEntity;
@@ -15,10 +17,8 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Queue\SerializesModels;
 use App\Classes\eHealth\EHealthResponse;
-use App\Core\Arr;
 use App\Enums\Employee\RevisionStatus;
 use App\Models\Employee\EmployeeRequest;
-use App\Models\User;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Middleware\RateLimited;
@@ -33,7 +33,7 @@ class EmployeeRequestDetailsUpsert extends EHealthJob
 
     public const string SCOPE_REQUIRED = 'employee_request:read';
 
-    public const string ENTITY = LegalEntity::ENTITY_EMPLOYEE;
+    public const string ENTITY = LegalEntity::ENTITY_EMPLOYEE_REQUEST;
 
     protected const int RATE_LIMIT_DELAY = 3;
 
@@ -46,9 +46,9 @@ class EmployeeRequestDetailsUpsert extends EHealthJob
         parent::__construct(legalEntity: $legalEntity, nextEntity: $nextEntity, standalone: $standalone);
     }
 
-    // Get data from EHealth API
-
     /**
+     * Get data from EHealth API
+     *
      * @throws ConnectionException
      */
     protected function sendRequest(string $token): PromiseInterface|EHealthResponse|null
@@ -56,9 +56,9 @@ class EmployeeRequestDetailsUpsert extends EHealthJob
         return EHealth::employeeRequest()->withToken($token)->getDetails($this->employeeRequest->uuid);
     }
 
-    // Store or update data in the database
-
     /**
+     * Store or update data in the database
+     *
      * @throws Throwable
      */
     protected function processResponse(?EHealthResponse $response): void
@@ -68,7 +68,6 @@ class EmployeeRequestDetailsUpsert extends EHealthJob
         Log::info('Processing EmployeeRequestDetailsUpsert for employee_request:' . $this->employeeRequest->id . ', LE:' . ($this->legalEntity->id ?? 'N/A'));
 
         $this->employeeRequest->legalEntityUuid = $this->legalEntity?->uuid;
-
 
         $userEmail = Arr::get($validatedData, 'party.email');
 

--- a/app/Jobs/EmployeeRequestsSyncAll.php
+++ b/app/Jobs/EmployeeRequestsSyncAll.php
@@ -20,7 +20,7 @@ class EmployeeRequestsSyncAll extends EHealthJob
 
     public const string BATCH_NAME = 'EmployeeRequestsSyncAll';
     public const string SCOPE_REQUIRED = 'employee_request:read';
-    public const string ENTITY = LegalEntity::ENTITY_EMPLOYEE;
+    public const string ENTITY = LegalEntity::ENTITY_EMPLOYEE_REQUEST;
 
     protected function sendRequest(string $token): PromiseInterface|EHealthResponse
     {
@@ -57,8 +57,10 @@ class EmployeeRequestsSyncAll extends EHealthJob
      */
     protected function getNextEntityJob(): ?EHealthJob
     {
-        return $this->standalone
+        $nextEntity = $this->nextEntity ?? $this->getEmployeeRequestDetailsStartJob($this->legalEntity, $this->nextEntity);
+
+        return $this->standalone || !$nextEntity
             ? new CompleteSync($this->legalEntity, isFirstLogin: $this->isFirstLogin)
-            : $this->getEmployeeRequestDetailsStartJob($this->legalEntity, $this->nextEntity);
+            : $nextEntity;
     }
 }

--- a/app/Jobs/EmployeeRoleSync.php
+++ b/app/Jobs/EmployeeRoleSync.php
@@ -11,6 +11,7 @@ use App\Repositories\Repository;
 use App\Classes\eHealth\EHealth;
 use GuzzleHttp\Promise\PromiseInterface;
 use App\Classes\eHealth\EHealthResponse;
+use App\Models\LegalEntity;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Queue\Middleware\RateLimited;
 use Throwable;
@@ -20,6 +21,8 @@ class EmployeeRoleSync extends EHealthJob
     public const string BATCH_NAME = 'EmployeeRoleSync';
 
     public const string SCOPE_REQUIRED = 'employee_role:read';
+
+    public const string ENTITY = LegalEntity::ENTITY_EMPLOYEE_ROLE;
 
     /**
      * Get data from EHealth API.

--- a/app/Jobs/EquipmentSync.php
+++ b/app/Jobs/EquipmentSync.php
@@ -11,6 +11,7 @@ use App\Repositories\Repository;
 use App\Classes\eHealth\EHealth;
 use GuzzleHttp\Promise\PromiseInterface;
 use App\Classes\eHealth\EHealthResponse;
+use App\Models\LegalEntity;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Queue\Middleware\RateLimited;
 use Throwable;
@@ -20,6 +21,8 @@ class EquipmentSync extends EHealthJob
     public const string BATCH_NAME = 'EquipmentSync';
 
     public const string SCOPE_REQUIRED = 'equipment:read';
+
+    public const string ENTITY = LegalEntity::ENTITY_EQUIPMENT;
 
     /**
      * Get data from EHealth API.

--- a/app/Jobs/LegalEntitySync.php
+++ b/app/Jobs/LegalEntitySync.php
@@ -7,27 +7,28 @@ namespace App\Jobs;
 use App\Core\EHealthJob;
 use GuzzleHttp\Promise\PromiseInterface;
 use App\Classes\eHealth\EHealthResponse;
+use App\Enums\JobStatus;
 
 /**
  * This job is responsible for finalizing a full synchronization operation between different data sources
  *
  * @package App\Jobs
  */
-class CompleteSync extends EHealthJob
+class LegalEntitySync extends EHealthJob
 {
-    public const string BATCH_NAME = 'CompleteSync';
+    public const string BATCH_NAME = 'LegalEntitySync';
 
     /**
      * Execute the job.
      */
     public function handle(): void
     {
-        echo 'Starting CompleteSync for legalEntity : ' . $this->legalEntity->id . PHP_EOL;
+        echo 'Starting LegalEntitySync for legalEntity : ' . $this->legalEntity->id . PHP_EOL;
 
         parent::handle();
 
-        //notify user about completion of sync of other entities (used for manual syncs)
-        $this->sendEntityNotification(null, 'completed');
+        $this->sendEntityNotification('legal_entity', 'completed');
+        $this->setEntityStatus(JobStatus::COMPLETED);
     }
 
     // Get data from EHealth API (here it mostly dummy method)

--- a/app/Listeners/FirstLoginOwnerSynchronization.php
+++ b/app/Listeners/FirstLoginOwnerSynchronization.php
@@ -8,7 +8,10 @@ use Throwable;
 use App\Enums\JobStatus;
 use App\Jobs\EmployeeSync;
 use App\Jobs\DivisionSync;
+use App\Jobs\EquipmentSync;
+use App\Jobs\LegalEntitySync;
 use App\Jobs\DeclarationsSync;
+use App\Jobs\EmployeeRoleSync;
 use App\Events\EHealthUserLogin;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Bus;
@@ -44,14 +47,35 @@ class FirstLoginOwnerSynchronization implements ShouldQueue
         // TODO: remove it after testing
         echo 'First login synchronization started. ' . 'legalEntity:' . $event->legalEntity->id. PHP_EOL;
 
+        // Create a chain of jobs for synchronization
+
+        // This is the last job in the chain
+        $legalEntityJob = new LegalEntitySync(
+            legalEntity: $event->legalEntity,
+            isFirstLogin: true
+        );
+
+        $equipmentJob = new EquipmentSync(
+            legalEntity: $event->legalEntity,
+            nextEntity: $legalEntityJob,
+            isFirstLogin: true
+        );
+
         $declarationJob = new DeclarationsSync(
             legalEntity: $event->legalEntity,
+            nextEntity: $equipmentJob,
+            isFirstLogin: true
+        );
+
+        $employeeRoleJob = new EmployeeRoleSync(
+            legalEntity: $event->legalEntity,
+            nextEntity: $declarationJob,
             isFirstLogin: true
         );
 
         $employeeJob = new EmployeeSync(
             legalEntity: $event->legalEntity,
-            nextEntity: $declarationJob,
+            nextEntity: $employeeRoleJob,
             isFirstLogin: true
         );
 

--- a/app/Listeners/OnRegularLoginSyncronization.php
+++ b/app/Listeners/OnRegularLoginSyncronization.php
@@ -3,7 +3,6 @@
 namespace App\Listeners;
 
 use Throwable;
-use App\Enums\JobStatus;
 use App\Events\EHealthUserLogin;
 use Illuminate\Support\Facades\Log;
 use App\Notifications\SyncNotification;
@@ -47,19 +46,9 @@ class OnRegularLoginSyncronization implements ShouldQueue
         foreach ($failedBatches as $batch) {
             echo 'Found related batch: ' . $batch->name . ' id: ' . $batch->id . PHP_EOL;
 
-            // Extract pending jobs from the batches
-            $pendingJobs = $this->extractPendingJobsFromBatches($batch);
-
-            if (empty($pendingJobs)) {
-                echo 'No pending jobs found in batch: ' . $batch->name . ' id: ' . $batch->id . PHP_EOL;
-
-                continue;
-            }
-
-            $this->restartFailedBatch($event->user, $batch, $event->token, $event->legalEntity, $pendingJobs);
+            $this->restartBatch($batch, $event->user, $event->token, $event->legalEntity);
         }
 
-        $event->legalEntity->setEntityStatus(JobStatus::PROCESSING);
         $event->user->notify(new SyncNotification('legal_entity', 'resumed'));
     }
 

--- a/app/Livewire/Contract/ContractIndex.php
+++ b/app/Livewire/Contract/ContractIndex.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Contract;
 
 use App\Classes\eHealth\EHealth;
 use App\Enums\Contract\Type;
+use App\Enums\JobStatus;
 use App\Models\Contract;
 use App\Models\LegalEntity;
 use App\Repositories\Repository;
@@ -88,6 +89,7 @@ class ContractIndex extends Component
             $this->isFiltersApplied = true;
             session()->flash('success', 'Дані успішно синхронізовано (' . count($items) . ' записів).');
 
+            legalEntity()?->setEntityStatus(JobStatus::COMPLETED, LegalEntity::ENTITY_CONTRACT);
         } catch (\Exception $e) {
             session()->flash('error', 'Помилка синхронізації: ' . $e->getMessage());
         }

--- a/app/Livewire/Declaration/DeclarationIndex.php
+++ b/app/Livewire/Declaration/DeclarationIndex.php
@@ -18,6 +18,7 @@ use App\Jobs\DeclarationsSync;
 use App\Repositories\Repository;
 use App\Classes\eHealth\EHealth;
 use App\Enums\Declaration\Status;
+use App\Enums\JobStatus;
 use App\Models\Employee\Employee;
 use Livewire\Attributes\Computed;
 use App\Models\DeclarationRequest;
@@ -35,6 +36,7 @@ use Illuminate\Http\Client\ConnectionException;
 use App\Notifications\DeclarationSyncCompleted;
 use App\Exceptions\EHealth\EHealthResponseException;
 use App\Exceptions\EHealth\EHealthValidationException;
+use App\Models\User;
 
 class DeclarationIndex extends Component
 {
@@ -42,12 +44,17 @@ class DeclarationIndex extends Component
         WithPagination,
         FormTrait;
 
+    protected const string BATCH_NAME = 'Declarations Full Sync';
+    protected const string SUB_BATCH_NAME = 'DeclarationRequests Full Sync';
+
     /**
      * Search by patient first and last names.
      *
      * @var string
      */
     public string $searchByName = '';
+
+    public string $syncStatus = '';
 
     /**
      * Search by declaration and declaration request number
@@ -95,6 +102,68 @@ class DeclarationIndex extends Component
 
     public bool $isFiltersApplied = false;
 
+    /**
+     * Determine if the declaration is synchronized.
+     *
+     * @return bool True if the declaration is synchronized, false otherwise.
+     */
+    #[Computed]
+    public function isSync(): bool
+    {
+       return $this->isSyncProcessing();
+    }
+
+    /**
+     * Get the synchronization status of the declarations
+     *
+     * @return string The current sync status
+     */
+    protected function getSyncStatus(): string
+    {
+        return legalEntity()?->getEntityStatus(LegalEntity::ENTITY_DECLARATION) ?? '';
+    }
+
+    /**
+     * Determine if a synchronization process is currently running.
+     *
+     * @return bool True if a sync process is actively processing, false otherwise.
+     */
+    protected function isSyncProcessing(): bool
+    {
+        // Get the sync status for whole Legal Entity
+        $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
+
+        // Get the sync status for Declaration Requests
+        $declarationRequestStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_DECLARATION_REQUEST);
+
+        // Set the sync status only for Declaration
+        $this->syncStatus = $this->getSyncStatus();
+
+        // Determine if either the Legal Entity's sync is in progress
+        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::COMPLETED->value && ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+
+        // Determine if either the DeclarationRequest's sync is in progress (declarations depends on it)
+        $declarationRequestSync = $declarationRequestStatus !== JobStatus::COMPLETED->value &&
+                                  $declarationRequestStatus !== JobStatus::PAUSED->value &&
+                                  $declarationRequestStatus !== JobStatus::FAILED->value &&
+                                  !empty($declarationRequestStatus);
+
+        // Determine if either the Declaration's sync is in progress
+        $declarationSync = $this->syncStatus !== JobStatus::COMPLETED->value &&
+                               $this->syncStatus !== JobStatus::PAUSED->value &&
+                               $this->syncStatus !== JobStatus::FAILED->value &&
+                               !empty($this->syncStatus);
+
+        // Return true if either sync is in progress
+        return $legalEntitySync || $declarationSync || $declarationRequestSync;
+    }
+
+    public function boot(): void
+    {
+        // This will ensure that the 'isSync' computed property is not cached between requests
+        unset($this->isSync);
+    }
+
     public function mount(LegalEntity $legalEntity): void
     {
         $user = Auth::user();
@@ -106,6 +175,8 @@ class DeclarationIndex extends Component
         } else {
             $this->countActive = Declaration::whereIn('employee_id', $this->employeeIds)->count();
         }
+
+        $this->syncStatus = $this->getSyncStatus();
     }
 
     public function search(): void
@@ -241,9 +312,16 @@ class DeclarationIndex extends Component
             return;
         }
 
+        if ($this->isSyncProcessing()) {
+            Session::flash('error', 'Синхронізація вже запущена. Будь ласка, зачекайте її завершення.');
+
+            return;
+        }
+
         $legalEntity = legalEntity();
 
         $user = Auth::user();
+        $token = session()->get(config('ehealth.api.oauth.bearer_token'));
         $user->notify(new SyncNotification('declaration', 'started'));
 
         // Get declarations from eHealth filtered by legal entity
@@ -280,8 +358,6 @@ class DeclarationIndex extends Component
             return;
         }
 
-        $token = session()->get(config('ehealth.api.oauth.bearer_token'));
-
         // Check if there are more pages to process
         if ($response->isNotLast()) {
             Bus::batch([
@@ -312,9 +388,13 @@ class DeclarationIndex extends Component
                     $user->notify(new DeclarationSyncCompleted($message, 'error'));
                 })
                 ->onQueue('sync')
-                ->name('Declarations Full Sync')
+                ->name(self::BATCH_NAME)
                 ->dispatch();
-        } else {
+
+                legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_DECLARATION);
+
+                session()->flash('success', __('declarations.sync.started'));
+        } else if (!empty($declarations['declarations'])) {
             Bus::batch($this->getDeclarationRequestsStartJob($legalEntity, null))
                 ->withOption('legal_entity_id', $legalEntity->id)
                 ->withOption('token', Crypt::encryptString($token))
@@ -337,11 +417,16 @@ class DeclarationIndex extends Component
                     $user->notify(new DeclarationSyncCompleted($message, 'error'));
                 })
                 ->onQueue('sync')
-                ->name('DeclarationRequest Full Sync')
+                ->name(self::SUB_BATCH_NAME)
                 ->dispatch();
-        }
 
-        session()->flash('success', __('declarations.sync.started'));
+                session()->flash('success', __('declarations.sync.started'));
+        } else {
+            // If there were no declarations to sync, mark the status as completed
+            legalEntity()?->setEntityStatus(JobStatus::COMPLETED, LegalEntity::ENTITY_DECLARATION);
+
+            session()->flash('success', );
+        }
     }
 
     public function approve(int $patientId, int $declarationRequestId): void

--- a/app/Livewire/Division/DivisionIndex.php
+++ b/app/Livewire/Division/DivisionIndex.php
@@ -6,9 +6,11 @@ namespace App\Livewire\Division;
 
 use Throwable;
 use Exception;
+use App\Enums\JobStatus;
 use App\Models\Division;
 use Illuminate\Bus\Batch;
 use App\Jobs\DivisionSync;
+use App\Models\LegalEntity;
 use Livewire\WithPagination;
 use App\Classes\eHealth\EHealth;
 use App\Repositories\Repository;
@@ -20,6 +22,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Session;
 use App\Notifications\SyncNotification;
+use App\Traits\BatchLegalEntityQueries;
 use App\Livewire\Division\Trait\HasAction;
 use Illuminate\Http\Client\ConnectionException;
 use App\Exceptions\EHealth\EHealthResponseException;
@@ -27,25 +30,67 @@ use App\Exceptions\EHealth\EHealthValidationException;
 
 class DivisionIndex extends DivisionComponent
 {
-    use WithPagination;
-    use HasAction;
+    use BatchLegalEntityQueries,
+        WithPagination,
+        HasAction;
+
+    protected const string BATCH_NAME = 'DivisionSync';
+
+    public string $syncStatus = '';
 
     #[Computed]
-    public function tableHeaders(): array
+    public function isSync(): bool
     {
-        return [
-            __('forms.name'),
-            __('forms.type'),
-            __('Телефон'),
-            __('Email'),
-            __('Статус'),
-            __('forms.action'),
-        ];
+       return $this->isSyncProcessing();
+    }
+
+    /**
+     * Get the current synchronization status
+     *
+     * @return string The synchronization status
+     */
+    protected function getSyncStatus(): string
+    {
+        return legalEntity()?->getEntityStatus(LegalEntity::ENTITY_DIVISION) ?? '';
+    }
+
+    /**
+     * Determine if a synchronization process is currently running.
+     *
+     * @return bool True if a sync process is actively processing, false otherwise.
+     */
+    protected function isSyncProcessing(): bool
+    {
+        // Get the sync status for whole Legal Entity
+        $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
+
+        // Get the sync status only for Division
+        $this->syncStatus = $this->getSyncStatus();
+
+        // Determine if either the Legal Entity's sync is in progress
+        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::COMPLETED->value && ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+
+        // Determine if either the Division's sync is in progress
+        $divisionSync = $this->syncStatus !== JobStatus::COMPLETED->value &&
+                        $this->syncStatus !== JobStatus::PAUSED->value &&
+                        $this->syncStatus !== JobStatus::FAILED->value &&
+                        !empty($this->syncStatus);
+
+        // Return true if either sync is in progress
+        return $legalEntitySync || $divisionSync;
+    }
+
+    public function boot(): void
+    {
+        // This will ensure that the 'isSync' computed property is not cached between requests
+        unset($this->isSync);
     }
 
     public function mount(): void
     {
         $this->setDictionary();
+
+        $this->syncStatus = $this->getSyncStatus();
     }
 
     /**
@@ -71,6 +116,22 @@ class DivisionIndex extends DivisionComponent
     {
         if (Auth::user()->cannot('viewAny', Division::class)) {
             Session::flash('error', 'У вас немає дозволу на синхронізацію місць надання послуг');
+
+            return;
+        }
+
+        if ($this->isSyncProcessing()) {
+            Session::flash('error', 'Синхронізація вже запущена. Будь ласка, зачекайте її завершення.');
+
+            return;
+        }
+
+        $user = Auth::user();
+        $token = session()->get(config('ehealth.api.oauth.bearer_token'));
+
+        // Try to resume if previous batch failed or was paused
+        if ($this->syncStatus === JobStatus::FAILED->value || $this->syncStatus === JobStatus::PAUSED->value) {
+           $this->resumeSyncronization($user, $token);
 
             return;
         }
@@ -107,9 +168,6 @@ class DivisionIndex extends DivisionComponent
 
         // If there are more pages, dispatch a job to handle the rest
         if ($response->isNotLast()) {
-            $token = session()->get(config('ehealth.api.oauth.bearer_token'));
-            $user = Auth::user();
-
             Bus::batch([
                 new DivisionSync(
                     legalEntity: legalEntity(),
@@ -132,17 +190,15 @@ class DivisionIndex extends DivisionComponent
                     $user->notify(new SyncNotification('division', 'failed'));
                 })
                 ->onQueue('sync')
-                ->name('DivisionSync')
+                ->name(self::BATCH_NAME)
                 ->dispatch();
+
+                legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_DIVISION);
 
                 session()->flash('success', __('Синхронізація запущена у фоновому режимі'));
         } else {
             session()->flash('success', __('Інформацію успішно оновлено'));
         }
-
-        $this->redirect(route('division.index', [legalEntity()]), navigate: true);
-
-        return;
     }
 
     public function render(): View

--- a/app/Livewire/Division/HealthcareService/HealthcareServiceIndex.php
+++ b/app/Livewire/Division/HealthcareService/HealthcareServiceIndex.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Division\HealthcareService;
 
 use App\Classes\eHealth\EHealth;
+use App\Enums\JobStatus;
 use App\Enums\Status;
 use App\Exceptions\EHealth\EHealthResponseException;
 use App\Exceptions\EHealth\EHealthValidationException;
@@ -58,6 +59,49 @@ class HealthcareServiceIndex extends Component
     public bool $isFiltersApplied = false;
 
     public array $dictionaryNames = ['DIVISION_TYPE', 'SPECIALITY_TYPE', 'PROVIDING_CONDITION'];
+
+    #[Computed]
+    public function isSync(): bool
+    {
+       return $this->isSyncProcessing();
+    }
+
+    /**
+     * Determine if a synchronization process is currently running.
+     *
+     * @return bool True if a sync process is actively processing, false otherwise.
+     */
+    protected function isSyncProcessing(): bool
+    {
+        // Get the sync status for whole Legal Entity
+        $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
+
+        // Get the sync status only for Division
+        $divisionSyncStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_DIVISION);
+
+        // Determine if either the Legal Entity's sync is in progress
+        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::FAILED->value && $legalEntitySyncStatus !== JobStatus::COMPLETED->value && ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+
+        // Determine if either the Division's sync is in progress
+        $divisionSync = $divisionSyncStatus !== JobStatus::COMPLETED->value && ($divisionSyncStatus !== JobStatus::PAUSED->value && !empty($divisionSyncStatus));
+
+        // Get the sync status only for Division
+        $hcsSyncStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_HEALTHCARE_SERVICE);
+
+        // Determine if either the Division's sync is in progress
+        $hcsSync = $hcsSyncStatus !== JobStatus::COMPLETED->value && ($hcsSyncStatus !== JobStatus::PAUSED->value && !empty($hcsSyncStatus));
+
+        $isDivisionsPresent = Division::all()->isNotEmpty();
+
+        // Return true if either sync is in progress
+        return $legalEntitySync || $divisionSync || !$isDivisionsPresent || $hcsSync;
+    }
+
+    public function boot(): void
+    {
+        // This will ensure that the 'isSync' computed property is not cached between requests
+        unset($this->isSync);
+    }
 
     public function mount(LegalEntity $legalEntity, Division $division): void
     {
@@ -184,6 +228,12 @@ class HealthcareServiceIndex extends Component
 
     public function sync(): void
     {
+        if ($this->isSyncProcessing()) {
+            Session::flash('error', 'Синхронізація вже запущена. Будь ласка, зачекайте її завершення.');
+
+            return;
+        }
+
         if (Auth::user()->cannot('sync', HealthcareService::class)) {
             Session::flash('error', 'У вас немає дозволу на синхронізацію послуг');
 
@@ -282,6 +332,8 @@ class HealthcareServiceIndex extends Component
             ->onQueue('sync')
             ->name('HealthcareServiceSync')
             ->dispatch();
+
+            legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_HEALTHCARE_SERVICE);
     }
 
     public function render(): View

--- a/app/Livewire/Employee/EmployeeIndex.php
+++ b/app/Livewire/Employee/EmployeeIndex.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Session;
 use JsonException;
 use Livewire\Attributes\Computed;
 use Livewire\WithPagination;
@@ -70,9 +71,41 @@ class EmployeeIndex extends EmployeeComponent
 
     private LegalEntity $legalEntity;
 
+   #[Computed]
+    public function isSync(): bool
+    {
+       return $this->isSyncProcessing();
+    }
+
+    /**
+     * Determine if a synchronization process is currently running.
+     *
+     * @return bool True if a sync process is actively processing, false otherwise.
+     */
+    protected function isSyncProcessing(): bool
+    {
+        // Get the sync status for whole Legal Entity
+        $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
+
+        // Get the sync status only for Division
+        $employeeSyncStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_EMPLOYEE);
+
+        // Determine if either the Legal Entity's sync is in progress
+        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::COMPLETED->value && ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+
+        // Determine if either the Division's sync is in progress
+        $employeeSync = $employeeSyncStatus !== JobStatus::COMPLETED->value && ($employeeSyncStatus !== JobStatus::PAUSED->value && !empty($employeeSyncStatus));
+
+        // Return true if either sync is in progress
+        return $legalEntitySync || $employeeSync;
+    }
+
     public function boot(): void
     {
         $this->legalEntity = legalEntity();
+
+        // This will ensure that the 'isSync' computed property is not cached between requests
+        unset($this->isSync);
     }
 
     public function mount(LegalEntity $legalEntity): void
@@ -267,6 +300,12 @@ class EmployeeIndex extends EmployeeComponent
      */
     public function sync(): void
     {
+        if ($this->isSyncProcessing()) {
+            Session::flash('error', 'Синхронізація вже запущена. Будь ласка, зачекайте її завершення.');
+
+            return;
+        }
+
         $user = Auth::user();
         $user->notify(new SyncNotification('employee', 'started'));
 
@@ -361,9 +400,14 @@ class EmployeeIndex extends EmployeeComponent
                 ->onQueue('sync')
                 ->name('Employee Full Sync')
                 ->dispatch();
-
-            // $this->batchId = $batch->id;
         }
+
+        legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_EMPLOYEE);
+
+        $this->dispatch('flashMessage', [
+            'message' => "Сторінка 1 оброблена. Решта завантажується фоново.",
+            'type' => 'success'
+        ]);
     }
 
     /**

--- a/app/Livewire/EmployeeRequest/EmployeeRequestIndex.php
+++ b/app/Livewire/EmployeeRequest/EmployeeRequestIndex.php
@@ -4,46 +4,105 @@ declare(strict_types=1);
 
 namespace App\Livewire\EmployeeRequest;
 
-use App\Classes\eHealth\EHealth;
-use App\Enums\Employee\RequestStatus;
-use App\Exceptions\EHealth\EHealthResponseException;
-use App\Jobs\EmployeeRequestsSyncAll;
-use App\Jobs\EmployeeSync;
-use App\Livewire\Employee\EmployeeComponent;
-use App\Models\Employee\EmployeeRequest;
-use App\Models\LegalEntity;
-use App\Notifications\EmployeeRequestSyncCompleted;
-use App\Notifications\EmployeeSyncCompleted;
-use App\Services\Employee\EmployeeRequestProcessor;
-use App\Traits\BatchLegalEntityQueries;
 use Auth;
-use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Facades\Log;
-use Livewire\Attributes\Computed;
-use Livewire\WithPagination;
-use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Crypt;
+use App\Enums\JobStatus;
 use Illuminate\Bus\Batch;
+use App\Models\LegalEntity;
+use Livewire\WithPagination;
+use App\Classes\eHealth\EHealth;
+use Livewire\Attributes\Computed;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Crypt;
+use App\Enums\Employee\RequestStatus;
+use App\Jobs\EmployeeRequestsSyncAll;
+use Illuminate\Support\Facades\Session;
+use App\Traits\BatchLegalEntityQueries;
+use App\Models\Employee\EmployeeRequest;
+use App\Livewire\Employee\EmployeeComponent;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Http\Client\ConnectionException;
+use App\Notifications\EmployeeRequestSyncCompleted;
+use App\Services\Employee\EmployeeRequestProcessor;
+use App\Exceptions\EHealth\EHealthResponseException;
 
 class EmployeeRequestIndex extends EmployeeComponent
 {
     use WithPagination,
         BatchLegalEntityQueries;
 
+    protected const string BATCH_NAME = 'EmployeeRequest Full Sync';
+    protected const string SUB_BATCH_NAME = 'EmployeeRequestRequests Full Sync';
+
     public string $search = '';
     public string $status = '';
+
+    /**
+     * Represents the current synchronization status for the component.
+     *
+     * @var string
+     */
+    public string $syncStatus = '';
+
     private LegalEntity $legalEntity;
+
+    #[Computed]
+    public function isSync(): bool
+    {
+       return $this->isSyncProcessing();
+    }
+
+    /**
+     * Get the synchronization status of the employee request.
+     *
+     * @return string The current sync status
+     */
+    protected function getSyncStatus(): string
+    {
+        return legalEntity()?->getEntityStatus(LegalEntity::ENTITY_EMPLOYEE_REQUEST) ?? '';
+    }
+
+    /**
+     * Determine if a synchronization process is currently running.
+     *
+     * @return bool True if a sync process is actively processing, false otherwise.
+     */
+    protected function isSyncProcessing(): bool
+    {
+        // Get the sync status for whole Legal Entity
+        $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
+
+        // Set the sync status only for EmployeeRequest
+        $this->syncStatus = $this->getSyncStatus();
+
+        // Determine if either the Legal Entity's sync is in progress
+        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::COMPLETED->value && ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+
+        // Determine if either the EmployeeRequest's sync is in progress
+        $employeeRequestSync = $this->syncStatus !== JobStatus::COMPLETED->value &&
+                               $this->syncStatus !== JobStatus::PAUSED->value &&
+                               $this->syncStatus !== JobStatus::FAILED->value &&
+                               !empty($this->syncStatus);
+
+        // Return true if either sync is in progress
+        return $legalEntitySync || $employeeRequestSync;
+    }
 
     public function boot(): void
     {
         $this->legalEntity = legalEntity();
+
+        // This will ensure that the 'isSync' computed property is not cached between requests
+        unset($this->isSync);
     }
 
     public function mount(LegalEntity $legalEntity): void
     {
         $this->legalEntity = $legalEntity;
+
         $this->loadDictionaries();
+
+        $this->syncStatus = $this->getSyncStatus();
     }
 
     public function updatedSearch(): void
@@ -128,7 +187,20 @@ class EmployeeRequestIndex extends EmployeeComponent
      */
     public function sync(EmployeeRequestProcessor $processor): void
     {
+        if (Auth::user()->cannot('viewAny', EmployeeRequest::class)) {
+            session()->flash('error', __('У вас немає дозволу на синхронізацію заявок'));
+
+            return;
+        }
+
+        if ($this->isSyncProcessing()) {
+            Session::flash('error', 'Синхронізація вже запущена. Будь ласка, зачекайте її завершення.');
+
+            return;
+        }
+
         $user = Auth::user();
+        $token = session()->get(config('ehealth.api.oauth.bearer_token'));
 
         // Notify start
         $this->dispatch('flashMessage', [
@@ -159,9 +231,7 @@ class EmployeeRequestIndex extends EmployeeComponent
 
         // 2. Process Page 1 immediately
         $validatedData = $response->validate();
-        $processedCount = $processor->processBatch($validatedData, legalEntity());
-
-        $token = session()->get(config('ehealth.api.oauth.bearer_token'));
+        $processor->processBatch($validatedData, legalEntity());
 
         // 3. Check if there are more pages
         if ($response->isNotLast()) {
@@ -189,7 +259,7 @@ class EmployeeRequestIndex extends EmployeeComponent
                     $user->notify(new EmployeeRequestSyncCompleted($message, 'error'));
                 })
                 ->onQueue('sync')
-                ->name('EmployeeRequest Full Sync')
+                ->name(self::BATCH_NAME)
                 ->dispatch();
         } else {
              Bus::batch($this->getEmployeeRequestDetailsStartJob($this->legalEntity, null))
@@ -208,14 +278,17 @@ class EmployeeRequestIndex extends EmployeeComponent
                     $user->notify(new EmployeeRequestSyncCompleted($message, 'error'));
                 })
                 ->onQueue('sync')
-                ->name('EmployeeRequest Details Full Sync')
+                ->name(self::SUB_BATCH_NAME)
                 ->dispatch();
         }
 
+        legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_EMPLOYEE_REQUEST);
+
         $this->dispatch('flashMessage', [
-                'message' => "Сторінка 1 оброблена ({$processedCount} оновлень). Решта завантажується фоново.",
-                'type' => 'success'
-            ]);
+            'message' => "Сторінка 1 оброблена. Решта завантажується фоново.",
+            'type' => 'success'
+        ]);
+
         // Force refresh of the table
         $this->resetPage();
     }

--- a/app/Livewire/EmployeeRole/EmployeeRoleIndex.php
+++ b/app/Livewire/EmployeeRole/EmployeeRoleIndex.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\EmployeeRole;
 
+use App\Enums\JobStatus;
 use App\Classes\eHealth\EHealth;
 use App\Exceptions\EHealth\EHealthResponseException;
 use App\Exceptions\EHealth\EHealthValidationException;
@@ -31,6 +32,8 @@ class EmployeeRoleIndex extends Component
 {
     use WithPagination;
     use FormTrait;
+
+    protected const string BATCH_NAME = 'EmployeeRoleSync';
 
     /**
      * Full name of employee.
@@ -61,6 +64,64 @@ class EmployeeRoleIndex extends Component
     public array $healthcareServiceSpecialityTypes;
 
     protected array $dictionaryNames = ['SPECIALITY_TYPE', 'PROVIDING_CONDITION'];
+
+    /**
+     * Represents the current synchronization status for the component.
+     *
+     * @var string
+     */
+    public string $syncStatus = '';
+
+    private LegalEntity $legalEntity;
+
+    #[Computed]
+    public function isSync(): bool
+    {
+       return $this->isSyncProcessing();
+    }
+
+    /**
+     * Get the synchronization status of the employee roles.
+     *
+     * @return string The current sync status
+     */
+    protected function getSyncStatus(): string
+    {
+        return legalEntity()?->getEntityStatus(LegalEntity::ENTITY_EMPLOYEE_ROLE) ?? '';
+    }
+
+    /**
+     * Determine if a synchronization process is currently running.
+     *
+     * @return bool True if a sync process is actively processing, false otherwise.
+     */
+    protected function isSyncProcessing(): bool
+    {
+        // Get the sync status for whole Legal Entity
+        $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
+
+        // Set the sync status only for Employee Role
+        $this->syncStatus = $this->getSyncStatus();
+
+        // Determine if either the Legal Entity's sync is in progress
+        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::COMPLETED->value &&
+                           ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+
+        // Determine if either the Employee Role's sync is in progress
+        $employeeRoleSync = $this->syncStatus !== JobStatus::COMPLETED->value &&
+                               $this->syncStatus !== JobStatus::PAUSED->value &&
+                               $this->syncStatus !== JobStatus::FAILED->value &&
+                               !empty($this->syncStatus);
+
+        // Return true if either sync is in progress
+        return $legalEntitySync || $employeeRoleSync;
+    }
+
+    public function boot(): void
+    {
+        // This will ensure that the 'isSync' computed property is not cached between requests
+        unset($this->isSync);
+    }
 
     public function mount(LegalEntity $legalEntity): void
     {
@@ -125,6 +186,18 @@ class EmployeeRoleIndex extends Component
 
     public function sync(): void
     {
+        if (Auth::user()->cannot('viewAny', EmployeeRole::class)) {
+            Session::flash('error', 'У вас немає дозволу на синхронізацію ролей співробітників');
+
+            return;
+        }
+
+        if ($this->isSyncProcessing()) {
+            Session::flash('error', 'Синхронізація вже запущена. Будь ласка, зачекайте її завершення.');
+
+            return;
+        }
+
         try {
             $response = EHealth::employeeRole()->getMany();
         } catch (ConnectionException $exception) {
@@ -199,8 +272,10 @@ class EmployeeRoleIndex extends Component
                 $user->notify(new SyncNotification('employee_role', 'failed'));
             })
             ->onQueue('sync')
-            ->name('EmployeeRoleSync')
+            ->name(self::BATCH_NAME)
             ->dispatch();
+
+        legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_EMPLOYEE_ROLE);
     }
 
     public function render(): View

--- a/app/Livewire/Equipment/EquipmentIndex.php
+++ b/app/Livewire/Equipment/EquipmentIndex.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Equipment;
 use App\Classes\eHealth\EHealth;
 use App\Enums\Equipment\AvailabilityStatus;
 use App\Enums\Equipment\Status;
+use App\Enums\JobStatus;
 use App\Exceptions\EHealth\EHealthResponseException;
 use App\Exceptions\EHealth\EHealthValidationException;
 use App\Jobs\EquipmentSync;
@@ -34,6 +35,8 @@ class EquipmentIndex extends Component
 {
     use WithPagination;
     use StatusTrait;
+
+    protected const string BATCH_NAME = 'EquipmentSync';
 
     /**
      * Search by equipment name and inventory number.
@@ -79,11 +82,71 @@ class EquipmentIndex extends Component
 
     public bool $isFiltersApplied = false;
 
+    /**
+     * Represents the current synchronization status for the component.
+     *
+     * @var string
+     */
+    public string $syncStatus = '';
+
+    private LegalEntity $legalEntity;
+
+    #[Computed]
+    public function isSync(): bool
+    {
+       return $this->isSyncProcessing();
+    }
+
+    /**
+     * Get the synchronization status of the equipment entity
+     *
+     * @return string The current sync status
+     */
+    protected function getSyncStatus(): string
+    {
+        return legalEntity()?->getEntityStatus(LegalEntity::ENTITY_EQUIPMENT) ?? '';
+    }
+
+    /**
+     * Determine if a synchronization process is currently running.
+     *
+     * @return bool True if a sync process is actively processing, false otherwise.
+     */
+    protected function isSyncProcessing(): bool
+    {
+        // Get the sync status for whole Legal Entity
+        $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
+
+        // Set the sync status only for Equipment
+        $this->syncStatus = $this->getSyncStatus();
+
+        // Determine if either the Legal Entity's sync is in progress
+        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::COMPLETED->value &&
+                           ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+
+        // Determine if either the Equipment's sync is in progress
+        $equipmentSync = $this->syncStatus !== JobStatus::COMPLETED->value &&
+                               $this->syncStatus !== JobStatus::PAUSED->value &&
+                               $this->syncStatus !== JobStatus::FAILED->value &&
+                               !empty($this->syncStatus);
+
+        // Return true if either sync is in progress
+        return $legalEntitySync || $equipmentSync;
+    }
+
+    public function boot(): void
+    {
+        // This will ensure that the 'isSync' computed property is not cached between requests
+        unset($this->isSync);
+    }
+
     public function mount(LegalEntity $legalEntity): void
     {
         $this->divisions = $legalEntity->divisions()->select(['id', 'name'])->get()->toArray();
         $this->statusFilter = Status::values();
         $this->availabilityStatusFilter = AvailabilityStatus::values();
+
+        $this->syncStatus = $this->getSyncStatus();
     }
 
     public function search(): void
@@ -103,6 +166,12 @@ class EquipmentIndex extends Component
     {
         if (Auth::user()->cannot('sync', Equipment::class)) {
             Session::flash('error', 'У вас немає дозволу на синхронізацію обладнань');
+
+            return;
+        }
+
+        if ($this->isSyncProcessing()) {
+            Session::flash('error', 'Синхронізація вже запущена. Будь ласка, зачекайте її завершення.');
 
             return;
         }
@@ -214,8 +283,10 @@ class EquipmentIndex extends Component
                 $user->notify(new SyncNotification('equipment', 'failed'));
             })
             ->onQueue('sync')
-            ->name('EquipmentSync')
+            ->name(self::BATCH_NAME)
             ->dispatch();
+
+        legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_EQUIPMENT);
     }
 
     public function render(): View

--- a/app/Livewire/LegalEntity/LegalEntityDetails.php
+++ b/app/Livewire/LegalEntity/LegalEntityDetails.php
@@ -4,10 +4,14 @@ namespace App\Livewire\LegalEntity;
 
 use Arr;
 use Throwable;
+use App\Enums\JobStatus;
 use App\Models\LegalEntity;
 use App\Classes\eHealth\EHealth;
+use Livewire\Attributes\Computed;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
+use App\Repositories\PhoneRepository;
+use App\Repositories\AddressRepository;
 use Spatie\Permission\PermissionRegistrar;
 use App\Exceptions\EHealth\EHealthResponseException;
 use App\Exceptions\EHealth\EHealthValidationException;
@@ -22,6 +26,40 @@ class LegalEntityDetails extends LegalEntityComponent
     public array $mainKVED = [];
 
     public array $additionalKVEDs = [];
+
+    #[Computed]
+    public function isSync(): bool
+    {
+       return $this->isSyncProcessing();
+    }
+
+    /**
+     * Determine if a synchronization process is currently running.
+     *
+     * @return bool True if a sync process is actively processing, false otherwise.
+     */
+    protected function isSyncProcessing(): bool
+    {
+        // Get the sync status for whole Legal Entity
+        $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
+
+        // Determine if either the Legal Entity's sync is in progress
+        return $legalEntitySyncStatus !== JobStatus::COMPLETED->value &&
+               $legalEntitySyncStatus !== JobStatus::FAILED->value &&
+               $legalEntitySyncStatus !== JobStatus::PAUSED->value &&
+               !empty($legalEntitySyncStatus);
+    }
+
+    public function boot(
+        AddressRepository $addressRepository,
+        PhoneRepository $phoneRepository
+    ): void
+    {
+        parent::boot($addressRepository, $phoneRepository);
+
+        // This will ensure that the 'isSync' computed property is not cached between requests
+        unset($this->isSync);
+    }
 
     public function mount(?LegalEntity $legalEntity = null): void
     {
@@ -217,6 +255,8 @@ class LegalEntityDetails extends LegalEntityComponent
             return;
         }
 
+        legalEntity()?->setEntityStatus(JobStatus::PROCESSING);
+
         $oldStatus = $this->legalEntity->status;
 
         try {
@@ -233,17 +273,23 @@ class LegalEntityDetails extends LegalEntityComponent
 
             session()->flash('error', __('errors.ehealth.messages.server_error'));
 
+            legalEntity()?->setEntityStatus(JobStatus::FAILED);
+
             return;
         } catch (EHealthValidationException $err) {
             Log::channel('e_health_errors')->error(self::class . ':syncLegalEntity', ['error' => $err->getDetails()]);
 
             session()->flash('error', __('errors.ehealth.messages.server_error'));
 
+            legalEntity()?->setEntityStatus(JobStatus::FAILED);
+
             return;
         } catch (Throwable $err) {
             Log::channel('db_errors')->error(static::class . ': [syncLegalEntity]: ', ['error' => $err->getMessage()]);
 
             session()->flash('error', __('legal-entity.request.sync.errors.fail'));
+
+            legalEntity()?->setEntityStatus(JobStatus::FAILED);
 
             return;
         }
@@ -268,6 +314,8 @@ class LegalEntityDetails extends LegalEntityComponent
         $this->redirect(route('legal-entity.details', [legalEntity()]), navigate: true);
 
         session()->flash('success', __('forms.update_successfull'));
+
+        legalEntity()?->setEntityStatus(JobStatus::COMPLETED);
 
         return;
     }

--- a/app/Livewire/License/LicenseIndex.php
+++ b/app/Livewire/License/LicenseIndex.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\License;
 
 use App\Classes\eHealth\EHealth;
+use App\Enums\JobStatus;
 use App\Exceptions\EHealth\EHealthResponseException;
 use App\Exceptions\EHealth\EHealthValidationException;
 use App\Models\LegalEntity;
@@ -68,6 +69,8 @@ class LicenseIndex extends Component
 
             return;
         }
+
+        legalEntity()?->setEntityStatus(JobStatus::COMPLETED, LegalEntity::ENTITY_LICENSE);
 
         Session::flash('success', __('licenses.success.sync'));
     }

--- a/app/Livewire/NotificationsDropdown.php
+++ b/app/Livewire/NotificationsDropdown.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Livewire;
 
-use App\Core\Arr;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Notifications\DatabaseNotificationCollection;
 use Illuminate\Support\Facades\Auth;

--- a/app/Models/LegalEntity.php
+++ b/app/Models/LegalEntity.php
@@ -38,10 +38,13 @@ class LegalEntity extends Model
     public const string ENTITY_DIVISION = 'division_';
     public const string ENTITY_HEALTHCARE_SERVICE = 'hcs_';
     public const string ENTITY_EMPLOYEE = 'employee_';
+    public const string ENTITY_EMPLOYEE_ROLE = 'employee_role_';
+    public const string ENTITY_EMPLOYEE_REQUEST = 'employee_request_';
     public const string ENTITY_LICENSE = 'license_';
-    public const string ENTITY_CONTRACT = 'contract_';
+    public const string ENTITY_CONTRACT = 'document_';
     public const string ENTITY_DECLARATION = 'declaration_';
     public const string ENTITY_DECLARATION_REQUEST = 'declaration_request_';
+    public const string ENTITY_EQUIPMENT = 'equipment_';
 
     protected $fillable = [
         'uuid',

--- a/app/Traits/BatchLegalEntityQueries.php
+++ b/app/Traits/BatchLegalEntityQueries.php
@@ -67,6 +67,54 @@ trait BatchLegalEntityQueries
     }
 
     /**
+     * Retrieves a failed batch by its name.
+     *
+     * @param string $batchName The name of the batch to retrieve
+     *
+     * @return stdClass|null The failed batch object if found, null otherwise
+     */
+    protected function getFailedBatch(string $batchName): ?stdClass
+    {
+        $batches = $this->findFailedBatchesByLegalEntity(legalEntity()->id, 'ASC') ;
+
+        if ($batches->isEmpty()) {
+            return null;
+        }
+
+        $batches = $batches->filter(fn($batch) => $batch->name === $batchName);
+
+        return $batches->isNotEmpty() ? $batches->first() : null;
+    }
+
+    /**
+     * Restart a failed batch by its batch object
+     *
+     * @param stdClass $batch The failed batch object
+     * @param User $user The user context for the new batch execution
+     * @param string $token Encrypted authentication token for API requests
+     * @param LegalEntity|null $legalEntity The legal entity context for the batch (optional)
+     *
+     * @return void
+     */
+    protected function restartBatch(stdClass $batch, User $user, string $token, ?LegalEntity $legalEntity = null): void
+    {
+        $legalEntity = $legalEntity ?? legalEntity();
+
+        $pendingJobs = $this->extractPendingJobsFromBatches($batch);
+
+        if (empty($pendingJobs)) {
+            // Here do echo only into the job context where legalEntity() is not set
+            if (!legalEntity()) {
+                echo 'No pending jobs found in batch: ' . $batch->name . ' id: ' . $batch->id . PHP_EOL;
+            }
+
+            return;
+        }
+
+        $this->restartFailedBatch($user, $batch, $token, $legalEntity, $pendingJobs);
+    }
+
+    /**
      * Find running (not finished, not cancelled) batches by legal entity ID
      *
      * @param int $legalEntityId
@@ -122,12 +170,18 @@ trait BatchLegalEntityQueries
             ->onQueue('sync')
             ->dispatch();
 
-        echo 'Dispatched new batch: ' . $newBatch->name . ' id: ' . $newBatch->id . PHP_EOL;
+        // Here do echo only into the job context where legalEntity() is not set
+        if (!legalEntity()) {
+         echo 'Dispatched new batch: ' . $newBatch->name . ' id: ' . $newBatch->id . PHP_EOL;
+        }
 
         // Delete the old failed batch to prevent clutter
         app(BatchRepository::class)->delete($batch->id);
 
-        echo 'Deleted old failed batch: ' . $batch->name . ' id: ' . $batch->id . PHP_EOL;
+        // Here do echo only into the job context where legalEntity() is not set
+        if (!legalEntity()) {
+            echo 'Deleted old failed batch: ' . $batch->name . ' id: ' . $batch->id . PHP_EOL;
+        }
     }
 
     /**
@@ -205,7 +259,7 @@ trait BatchLegalEntityQueries
         }
 
         // Here $job is the first job in the chain (or null if no employees)
-        return $job;
+        return $job ?? $previousJob;
     }
 
     /**
@@ -242,7 +296,7 @@ trait BatchLegalEntityQueries
         }
 
         // Here $job is the first job in the chain (or null if no employees)
-        return $job;
+        return $job ?? $previousJob;
     }
 
     /**
@@ -280,7 +334,7 @@ trait BatchLegalEntityQueries
         }
 
         // Here $job is the first job in the chain (or null if no declarations)
-        return $job;
+        return $job ?? $previousJob;
     }
 
     /**
@@ -318,7 +372,7 @@ trait BatchLegalEntityQueries
         }
 
         // Here $job is the first job in the chain (or null if no declarationRequests)
-        return $job;
+        return $job ?? $previousJob;
     }
 
     /**
@@ -355,6 +409,6 @@ trait BatchLegalEntityQueries
         }
 
         // Here $job is the first job in the chain (or null if no employees)
-        return $job;
+        return $job ?? $previousJob;
     }
 }

--- a/database/migrations/install/2025_12_10_000014_create_legal_entities_table.php
+++ b/database/migrations/install/2025_12_10_000014_create_legal_entities_table.php
@@ -40,10 +40,13 @@ return new class extends Migration
             $table->enum('division_sync_status', JobStatus::values())->nullable();
             $table->enum('hcs_sync_status', JobStatus::values())->nullable();
             $table->enum('employee_sync_status', JobStatus::values())->nullable();
+            $table->enum('employee_role_sync_status', JobStatus::values())->nullable();
+            $table->enum('employee_request_sync_status', JobStatus::values())->nullable();
             $table->enum('license_sync_status', JobStatus::values())->nullable();
             $table->enum('document_sync_status', JobStatus::values())->nullable();
             $table->enum('declaration_sync_status', JobStatus::values())->nullable();
             $table->enum('declaration_request_sync_status', JobStatus::values())->nullable();
+            $table->enum('equipment_sync_status', JobStatus::values())->nullable();
             $table->timestamp('inserted_at')->nullable();
             $table->date('ehealth_inserted_at')->nullable();
             $table->uuid('ehealth_inserted_by')->nullable();

--- a/database/migrations/update/0_1/2026_01_19_200731_add_employee_request_sync_to_legal_entities.php
+++ b/database/migrations/update/0_1/2026_01_19_200731_add_employee_request_sync_to_legal_entities.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Enums\JobStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('legal_entities', function (Blueprint $table) {
+            if (! Schema::hasColumn('legal_entities', 'employee_request_sync_status')) {
+                $table->enum('employee_request_sync_status', JobStatus::values())->nullable();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('legal_entities', function (Blueprint $table) {
+            if (Schema::hasColumn('legal_entities', 'employee_request_sync_status')) {
+                $table->dropColumn('employee_request_sync_status');
+            }
+        });
+    }
+};

--- a/database/migrations/update/0_1/2026_01_23_132617_add_equipment_sync_to_legal_entities.php
+++ b/database/migrations/update/0_1/2026_01_23_132617_add_equipment_sync_to_legal_entities.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Enums\JobStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('legal_entities', function (Blueprint $table) {
+            if (! Schema::hasColumn('legal_entities', 'equipment_sync_status')) {
+                $table->enum('equipment_sync_status', JobStatus::values())->nullable();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('legal_entities', function (Blueprint $table) {
+            if (Schema::hasColumn('legal_entities', 'equipment_sync_status')) {
+                $table->dropColumn('equipment_sync_status');
+            }
+        });
+    }
+};

--- a/database/migrations/update/0_1/2026_01_23_142945_add_employee_role_sync_to_legal_entities.php
+++ b/database/migrations/update/0_1/2026_01_23_142945_add_employee_role_sync_to_legal_entities.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Enums\JobStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('legal_entities', function (Blueprint $table) {
+            if (! Schema::hasColumn('legal_entities', 'employee_role_sync_status')) {
+                $table->enum('employee_role_sync_status', JobStatus::values())->nullable();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('legal_entities', function (Blueprint $table) {
+            if (Schema::hasColumn('legal_entities', 'employee_role_sync_status')) {
+                $table->dropColumn('employee_role_sync_status');
+            }
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -285,6 +285,10 @@ input:-webkit-autofill ~ .label {
     @apply cursor-pointer inline-flex items-center justify-center font-medium rounded-lg text-sm px-5 py-2.5 text-white bg-green-700 hover:bg-green-800 focus:ring-4 focus:ring-green-300 dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-green-800;
 }
 
+.button-sync-disabled {
+    @apply cursor-pointer inline-flex items-center justify-center font-medium rounded-lg text-sm px-5 py-2.5 text-white bg-green-700 hover:bg-green-800 focus:ring-4 focus:ring-green-300 dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-green-800 opacity-30 cursor-default!;
+}
+
 .button-danger {
     @apply cursor-pointer focus:outline-none text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 me-2 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900;
 }

--- a/resources/lang/uk/forms.php
+++ b/resources/lang/uk/forms.php
@@ -220,6 +220,7 @@ return [
     'no_positions_found' => 'Посади відсутні',
     'application_register' => 'Реєстр заявок співробітників',
     'sync_all' => 'Синхронізувати всі',
+    'sync_retry' => 'Продовжити синхронізацію',
 
     // Documents
     'documents' => 'Документи',

--- a/resources/views/livewire/declaration/declaration-index.blade.php
+++ b/resources/views/livewire/declaration/declaration-index.blade.php
@@ -8,9 +8,14 @@
         <x-slot name="title">{{ __('forms.declarations') }}</x-slot>
 
         <div class="ml-auto flex items-center gap-2 mt-2 lg:mt-0">
-            <button  wire:click="sync" :key="sync-button" class="button-sync flex items-center gap-2 whitespace-nowrap">
+            <button
+                :key="sync-button"
+                wire:click="{{ !$this->isSync ? 'sync' : '' }}"
+                class="{{ $this->isSync ? 'button-sync-disabled' : 'button-sync' }} flex items-center gap-2 whitespace-nowrap"
+                {{ $this->isSync ? 'disabled' : '' }}
+            >
                 @icon('refresh', 'w-4 h-4')
-                {{ __('forms.synchronise_with_eHealth') }}
+                <span>{{ __('forms.synchronise_with_eHealth') }}</span>
             </button>
         </div>
 

--- a/resources/views/livewire/division/division-index.blade.php
+++ b/resources/views/livewire/division/division-index.blade.php
@@ -24,9 +24,13 @@
                 </a>
             @endcan
 
-            <button wire:click="sync" class="button-sync flex items-center gap-2 whitespace-nowrap">
+            <button
+                wire:click="{{ !$this->isSync ? 'sync' : '' }}"
+                class="{{ $this->isSync ? 'button-sync-disabled' : 'button-sync' }} flex items-center gap-2 whitespace-nowrap"
+                {{ $this->isSync ? 'disabled' : '' }}
+            >
                 @icon('refresh', 'w-4 h-4')
-                {{ __('forms.synchronise_with_eHealth') }}
+                <span>{{ __('forms.synchronise_with_eHealth') }}</span>
             </button>
         </div>
     </x-header-navigation>

--- a/resources/views/livewire/division/healthcare-service/healthcare-service-index.blade.php
+++ b/resources/views/livewire/division/healthcare-service/healthcare-service-index.blade.php
@@ -40,7 +40,11 @@
                         @endif
 
                         @can('sync', HealthcareService::class)
-                            <button wire:click="sync" class="button-sync flex items-center gap-2">
+                            <button
+                                wire:click="{{ !$this->isSync ? 'sync' : '' }}"
+                                class="{{ $this->isSync ? 'button-sync-disabled' : 'button-sync' }} flex items-center gap-2 whitespace-nowrap"
+                                {{ $this->isSync ? 'disabled' : '' }}
+                            >
                                 @icon('refresh', 'w-4 h-4')
                                 {{ __('forms.synchronise_with_eHealth') }}
                             </button>

--- a/resources/views/livewire/employee-request/employee-request-index.blade.php
+++ b/resources/views/livewire/employee-request/employee-request-index.blade.php
@@ -18,7 +18,12 @@
         </x-slot>
 
         <div class="mt-3 ml-0 flex flex-col sm:flex-row sm:flex-wrap gap-2 self-start">
-            <button wire:click="sync" wire:loading.attr="disabled" class="button-sync flex items-center gap-2">
+            <button
+                wire:click="{{ !$this->isSync ? 'sync' : '' }}"
+                wire:loading.attr="disabled"
+                class="{{ $this->isSync ? 'button-sync-disabled' : 'button-sync' }} flex items-center gap-2 whitespace-nowrap"
+                {{ $this->isSync ? 'disabled' : '' }}
+            >
                 <span wire:loading.remove wire:target="sync">@icon('refresh', 'w-4 h-4')</span>
                 <span wire:loading wire:target="sync" class="animate-spin">@icon('refresh', 'w-4 h-4')</span>
                 <span>{{ __('forms.sync_all') }}</span>
@@ -150,6 +155,6 @@
             {{ $requests->links() }}
         </div>
     </div>
-    <x-forms.loading/>
+    <x-forms.loading wire:target="sync"/>
 </div>
 </div>

--- a/resources/views/livewire/employee-role/employee-role-index.blade.php
+++ b/resources/views/livewire/employee-role/employee-role-index.blade.php
@@ -18,7 +18,12 @@
                 </a>
             @endcan
 
-            <button wire:click="sync" type="button" class="button-sync flex items-center gap-2 whitespace-nowrap">
+            <button
+                type="button"
+                wire:click="{{ !$this->isSync ? 'sync' : '' }}"
+                class="{{ $this->isSync ? 'button-sync-disabled' : 'button-sync' }} flex items-center gap-2 whitespace-nowrap"
+                {{ $this->isSync ? 'disabled' : '' }}
+            >
                 @icon('refresh', 'w-4 h-4')
                 {{ __('forms.synchronise_with_eHealth') }}
             </button>

--- a/resources/views/livewire/employee/employee-index.blade.php
+++ b/resources/views/livewire/employee/employee-index.blade.php
@@ -25,7 +25,12 @@
             <div class="mt-3 ml-0 flex flex-col sm:flex-row sm:flex-wrap gap-2 self-start">
                 <a href="{{ route('employee-request.create', ['legalEntity' => $currentLegalEntityId]) }}"
                    class="button-primary">{{ __('forms.new_employee') }}</a>
-                <button wire:click="sync" type="button" class="button-sync flex items-center gap-2 whitespace-nowrap">
+                <button
+                    wire:click="{{ !$this->isSync ? 'sync' : '' }}"
+                    type="button"
+                    class="{{ $this->isSync ? 'button-sync-disabled' : 'button-sync' }} flex items-center gap-2 whitespace-nowrap"
+                    {{ $this->isSync ? 'disabled' : '' }}
+                >
                     @icon('refresh', 'w-4 h-4')
                     {{ __('forms.synchronise_with_eHealth') }}
                 </button>

--- a/resources/views/livewire/equipment/equipment-index.blade.php
+++ b/resources/views/livewire/equipment/equipment-index.blade.php
@@ -19,7 +19,12 @@
             </a>
 
             @can('sync', Equipment::class)
-                <button wire:click="sync" type="button" class="button-sync flex items-center gap-2 whitespace-nowrap">
+                <button
+                    type="button"
+                    wire:click="{{ !$this->isSync ? 'sync' : '' }}"
+                    class="{{ $this->isSync ? 'button-sync-disabled' : 'button-sync' }} flex items-center gap-2 whitespace-nowrap"
+                    {{ $this->isSync ? 'disabled' : '' }}
+                >
                     @icon('refresh', 'w-4 h-4')
                     {{ __('forms.synchronise_with_eHealth') }}
                 </button>

--- a/resources/views/livewire/legal-entity/legal-entity-details.blade.php
+++ b/resources/views/livewire/legal-entity/legal-entity-details.blade.php
@@ -36,7 +36,11 @@
         @if(auth()->getDefaultDriver() === 'ehealth')
             @can('sync', [LegalEntity::class, $le])
                 <div class="flex flex-wrap items-end justify-between gap-4 max-w-6xl">
-                    <button wire:click="sync" class="button-sync flex items-center gap-2">
+                    <button
+                        wire:click="{{ !$this->isSync ? 'sync' : '' }}"
+                        class="{{ $this->isSync ? 'button-sync-disabled' : 'button-sync' }} flex items-center gap-2 whitespace-nowrap"
+                        {{ $this->isSync ? 'disabled' : '' }}
+                    >
                         @icon('refresh', 'w-4 h-4')
                         {{ __('forms.synchronise_with_eHealth') }}
                     </button>


### PR DESCRIPTION
Що було зроблено:
- додано блокування кнопки синхронізації місць надання послуг на час самого процесу синхронізації;
- додано блокування кнопки синхронізації послуг на час самого процесу синхронізації;
- додано блокування кнопки синхронізації співробітників на час самого процесу синхронізації;
- додано блокування кнопки синхронізації заявок на час самого процесу синхронізації;
- додано блокування кнопки синхронізації деталей закладу на час самого процесу синхронізації;
- проведено рефакторинг механізму запуску джобів для можливості здійснення перезапуску синхронізації після помилки або збою;
- додано атрибут синхронізації employee_request_sync_status для моделі EmployeeRequest в таблицю legal_entities;
- додано атрибут синхронізації equipment_sync_status для моделі Equipment в таблицю legal_entities;
- додано атрибут синхронізації employee_role_sync_status для моделі EmployeeRole в таблицю legal_entities;
- пофікшено логіку обробки залежних джобів, для сутностей, які на момент роботи ще не мають ніяких даних;
- для EmployeeDetails, Division, HealthcareService, Employee, EmployeeRole, Declaration, Equipment - при першому вході кнопки синхронізації залишаються заблокованими до кінця синхронізації закладу, навіть після закінчення синхронізації окремої сутності.