### PR TITLE
#663: continue synchronization after being paused or failed

### DIFF
--- a/app/Classes/eHealth/Api/License.php
+++ b/app/Classes/eHealth/Api/License.php
@@ -128,7 +128,7 @@ class License extends Request
     {
         return [
             'active_from_date' => 'required|date_format:Y-m-d',
-            'expiry_date' => 'required|date_format:Y-m-d',
+            'expiry_date' => 'nullable|date_format:Y-m-d',
             'uuid' => 'required|uuid',
             'is_active' => 'required|boolean',
             'is_primary' => 'required|boolean',

--- a/app/Core/EHealthJob.php
+++ b/app/Core/EHealthJob.php
@@ -8,6 +8,7 @@ use Throwable;
 use App\Models\User;
 use App\Enums\JobStatus;
 use Illuminate\Bus\Batch;
+use App\Traits\FormTrait;
 use App\Jobs\CompleteSync;
 use App\Models\LegalEntity;
 use Illuminate\Bus\Batchable;
@@ -28,6 +29,7 @@ abstract class EHealthJob implements ShouldQueue
 {
     use Queueable,
         Batchable,
+        FormTrait,
         InteractsWithQueue,
         BatchLegalEntityQueries;
 

--- a/app/Jobs/DeclarationRequestDetailsSync.php
+++ b/app/Jobs/DeclarationRequestDetailsSync.php
@@ -34,7 +34,7 @@ class DeclarationRequestDetailsSync extends EHealthJob
 
     public const string SCOPE_REQUIRED = 'declaration_request:read';
 
-    public const string ENTITY = LegalEntity::ENTITY_DECLARATION_REQUEST;
+    public const string ENTITY = LegalEntity::ENTITY_DECLARATION;
 
     public function __construct(
         public DeclarationRequest $declarationRequest,

--- a/app/Jobs/EmployeeRoleSync.php
+++ b/app/Jobs/EmployeeRoleSync.php
@@ -47,7 +47,7 @@ class EmployeeRoleSync extends EHealthJob
      */
     protected function processResponse(?EHealthResponse $response): void
     {
-        $employeeRolesData = $response?->validate();
+        $employeeRolesData = $this->normalizeDate($response?->validate());
 
         if (empty($employeeRolesData)) {
             return;

--- a/app/Jobs/EquipmentSync.php
+++ b/app/Jobs/EquipmentSync.php
@@ -45,7 +45,7 @@ class EquipmentSync extends EHealthJob
      */
     protected function processResponse(?EHealthResponse $response): void
     {
-        $healthcareServicesData = $response?->validate();
+        $healthcareServicesData = $this->normalizeDate($response?->validate());
 
         if (empty($healthcareServicesData)) {
             return;

--- a/app/Jobs/LegalEntitySync.php
+++ b/app/Jobs/LegalEntitySync.php
@@ -7,7 +7,6 @@ namespace App\Jobs;
 use App\Core\EHealthJob;
 use GuzzleHttp\Promise\PromiseInterface;
 use App\Classes\eHealth\EHealthResponse;
-use App\Enums\JobStatus;
 
 /**
  * This job is responsible for finalizing a full synchronization operation between different data sources
@@ -28,7 +27,6 @@ class LegalEntitySync extends EHealthJob
         parent::handle();
 
         $this->sendEntityNotification('legal_entity', 'completed');
-        $this->setEntityStatus(JobStatus::COMPLETED);
     }
 
     // Get data from EHealth API (here it mostly dummy method)
@@ -50,5 +48,15 @@ class LegalEntitySync extends EHealthJob
     protected function getAdditionalMiddleware(): array
     {
         return [];
+    }
+
+    // Get next entity job if needed
+    protected function getNextEntityJob(): ?EHealthJob
+    {
+        $nextEntity = $this->nextEntity ?? $this->getConfidantPersonStartJob($this->legalEntity, null);
+
+        return $this->standalone || !$nextEntity
+            ? new CompleteSync($this->legalEntity, isFirstLogin: $this->isFirstLogin)
+            : $nextEntity;
     }
 }

--- a/app/Listeners/OnRegularLoginSyncronization.php
+++ b/app/Listeners/OnRegularLoginSyncronization.php
@@ -3,6 +3,7 @@
 namespace App\Listeners;
 
 use Throwable;
+use App\Enums\JobStatus;
 use App\Events\EHealthUserLogin;
 use Illuminate\Support\Facades\Log;
 use App\Notifications\SyncNotification;
@@ -14,6 +15,8 @@ class OnRegularLoginSyncronization implements ShouldQueue
 {
     use InteractsWithQueue,
         BatchLegalEntityQueries;
+
+    protected const string FIRST_LOGIN_BATCH_NAME = 'FirstLoginSync';
 
     /**
      * This listener will be placed on the 'sync' queue
@@ -45,6 +48,10 @@ class OnRegularLoginSyncronization implements ShouldQueue
 
         foreach ($failedBatches as $batch) {
             echo 'Found related batch: ' . $batch->name . ' id: ' . $batch->id . PHP_EOL;
+
+            if ($batch->name === self::FIRST_LOGIN_BATCH_NAME) {
+                $event->legalEntity?->setEntityStatus(JobStatus::PROCESSING);
+            }
 
             $this->restartBatch($batch, $event->user, $event->token, $event->legalEntity);
         }

--- a/app/Livewire/Contract/ContractIndex.php
+++ b/app/Livewire/Contract/ContractIndex.php
@@ -89,7 +89,7 @@ class ContractIndex extends Component
             $this->isFiltersApplied = true;
             session()->flash('success', 'Дані успішно синхронізовано (' . count($items) . ' записів).');
 
-            legalEntity()?->setEntityStatus(JobStatus::COMPLETED, LegalEntity::ENTITY_CONTRACT);
+            legalEntity()?->setEntityStatus(JobStatus::COMPLETED, LegalEntity::ENTITY_DOCUMENT);
         } catch (\Exception $e) {
             session()->flash('error', 'Помилка синхронізації: ' . $e->getMessage());
         }

--- a/app/Livewire/Declaration/DeclarationIndex.php
+++ b/app/Livewire/Declaration/DeclarationIndex.php
@@ -7,7 +7,9 @@ namespace App\Livewire\Declaration;
 use App\Enums\User\Role;
 use Throwable;
 use Exception;
+use App\Models\User;
 use Livewire\Component;
+use App\Enums\JobStatus;
 use Illuminate\View\View;
 use Illuminate\Bus\Batch;
 use App\Traits\FormTrait;
@@ -19,7 +21,6 @@ use App\Jobs\DeclarationsSync;
 use App\Repositories\Repository;
 use App\Classes\eHealth\EHealth;
 use App\Enums\Declaration\Status;
-use App\Enums\JobStatus;
 use App\Models\Employee\Employee;
 use Livewire\Attributes\Computed;
 use App\Models\DeclarationRequest;
@@ -44,8 +45,9 @@ class DeclarationIndex extends Component
     use WithPagination;
     use FormTrait;
 
-    protected const string BATCH_NAME = 'Declarations Full Sync';
-    protected const string SUB_BATCH_NAME = 'DeclarationRequests Full Sync';
+    protected const string BATCH_NAME = 'DeclarationsSync';
+    protected const string SUB_BATCH_NAME = 'DeclarationDetailsSync';
+    protected const string DEPENDENT_BATCH_NAME = 'DeclarationRequestDetailsSync';
 
     /**
      * Search by patient first and last names.
@@ -54,6 +56,11 @@ class DeclarationIndex extends Component
      */
     public string $searchByName = '';
 
+    /**
+     * Represents the current synchronization status for the component.
+     *
+     * @var string
+     */
     public string $syncStatus = '';
 
     /**
@@ -133,29 +140,39 @@ class DeclarationIndex extends Component
         // Get the sync status for whole Legal Entity
         $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
 
-        // Get the sync status for Declaration Requests
-        $declarationRequestStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_DECLARATION_REQUEST);
+        // Get the sync status only for Division
+        $divisionSyncStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_DIVISION);
+
+        // Get the sync status only for HealthCare Service
+        $healthCareServiceSyncStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_HEALTHCARE_SERVICE);
+
+        // Get the sync status only for HealthCare Service
+        $employeeSyncStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_EMPLOYEE);
 
         // Set the sync status only for Declaration
         $this->syncStatus = $this->getSyncStatus();
 
         // Determine if either the Legal Entity's sync is in progress
-        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::COMPLETED->value && ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+        $legalEntitySync = $this->isEntitySyncIsInProgress($legalEntitySyncStatus, true);
 
-        // Determine if either the DeclarationRequest's sync is in progress (declarations depends on it)
-        $declarationRequestSync = $declarationRequestStatus !== JobStatus::COMPLETED->value &&
-            $declarationRequestStatus !== JobStatus::PAUSED->value &&
-            $declarationRequestStatus !== JobStatus::FAILED->value &&
-            !empty($declarationRequestStatus);
+        // Determine if either the Division's sync is in progress
+        $divisionSync = $divisionSyncStatus !== JobStatus::COMPLETED->value;
+
+        // Determine if either the HealthCare Service's sync is in progress
+        $healthCareServiceSync = $healthCareServiceSyncStatus !== JobStatus::COMPLETED->value;
+
+        // Determine if either the Employee's sync is in progress
+        $employeeSync = $employeeSyncStatus !== JobStatus::COMPLETED->value;
 
         // Determine if either the Declaration's sync is in progress
-        $declarationSync = $this->syncStatus !== JobStatus::COMPLETED->value &&
-            $this->syncStatus !== JobStatus::PAUSED->value &&
-            $this->syncStatus !== JobStatus::FAILED->value &&
-            !empty($this->syncStatus);
+        $declarationSync = $this->isEntitySyncIsInProgress($this->syncStatus);
 
         // Return true if either sync is in progress
-        return $legalEntitySync || $declarationSync || $declarationRequestSync;
+        return $legalEntitySync ||
+               $declarationSync ||
+               $divisionSync ||
+               $healthCareServiceSync ||
+               $employeeSync;
     }
 
     public function boot(): void
@@ -323,6 +340,18 @@ class DeclarationIndex extends Component
         $token = Session::get(config('ehealth.api.oauth.bearer_token'));
         $user->notify(new SyncNotification('declaration', 'started'));
 
+        // Try to resume previous sync if it was paused or failed
+        if ($this->syncStatus === JobStatus::PAUSED->value || $this->syncStatus === JobStatus::FAILED->value) {
+
+            $this->resumeSynchronization($user, $token);
+
+            Session::flash('success', __('Відновлення попередньої синхронізації розпочато'));
+
+            $user->notify(new SyncNotification('declaration', 'resumed'));
+
+            return;
+        }
+
         // Get declarations from eHealth filtered by legal entity
         $query = ['legal_entity_id' => $legalEntity->uuid];
 
@@ -414,18 +443,50 @@ class DeclarationIndex extends Component
                             'exception' => $err
                         ]);
 
-                        $user->notify(new DeclarationSyncCompleted($message, 'error'));
-                    })
-                    ->onQueue('sync')
-                    ->name(self::SUB_BATCH_NAME)
-                    ->dispatch();
+                    $user->notify(new DeclarationSyncCompleted($message, 'error'));
+                })
+                ->onQueue('sync')
+                ->name(self::DEPENDENT_BATCH_NAME)
+                ->dispatch();
+
+                legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_DECLARATION);
 
                 Session::flash('success', __('declarations.sync.started'));
             } else {
                 // If there were no declarations to sync, mark the status as completed
                 legalEntity()?->setEntityStatus(JobStatus::COMPLETED, LegalEntity::ENTITY_DECLARATION);
 
-                Session::flash('success');
+                session()->flash('success', __('declarations.sync.completed'));
+            }
+        }
+    }
+
+    /**
+     * Resume the synchronization process for a user with the provided token.
+     *
+     * This method handles the continuation of a previously initiated synchronization
+     * operation for a specific user using an authentication or session token.
+     *
+     * @param User $user The user instance for whom synchronization should be resumed
+     * @param string $token The authentication or session token used to resume the sync process
+     * @return void
+     */
+    protected function resumeSynchronization(User $user, string $token): void
+    {
+        $encryptedToken = Crypt::encryptString($token);
+
+        // Find all the EmployeeRequests failed batches for this legal entity and retry them
+        $failedBatches = $this->findFailedBatchesByLegalEntity(legalEntity()->id, 'ASC');
+
+        foreach ($failedBatches as $batch) {
+            if ($batch->name === self::BATCH_NAME || $batch->name === self::SUB_BATCH_NAME || $batch->name === self::DEPENDENT_BATCH_NAME) {
+                Log::info('Resuming Declaration sync batch: ' . $batch->name . ' id: ' . $batch->id);
+
+                legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_DECLARATION);
+
+                $this->restartBatch($batch, $user, $encryptedToken, legalEntity());
+
+                break;
             }
         }
     }

--- a/app/Livewire/Division/DivisionIndex.php
+++ b/app/Livewire/Division/DivisionIndex.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Division;
 
 use Throwable;
 use Exception;
+use App\Models\User;
 use App\Enums\JobStatus;
 use App\Models\Division;
 use Illuminate\Bus\Batch;
@@ -36,6 +37,11 @@ class DivisionIndex extends DivisionComponent
 
     protected const string BATCH_NAME = 'DivisionSync';
 
+    /**
+     * Represents the current synchronization status for the component.
+     *
+     * @var string
+     */
     public string $syncStatus = '';
 
     #[Computed]
@@ -68,13 +74,10 @@ class DivisionIndex extends DivisionComponent
         $this->syncStatus = $this->getSyncStatus();
 
         // Determine if either the Legal Entity's sync is in progress
-        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::COMPLETED->value && ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+        $legalEntitySync = $this->isEntitySyncIsInProgress($legalEntitySyncStatus, true);
 
         // Determine if either the Division's sync is in progress
-        $divisionSync = $this->syncStatus !== JobStatus::COMPLETED->value &&
-                        $this->syncStatus !== JobStatus::PAUSED->value &&
-                        $this->syncStatus !== JobStatus::FAILED->value &&
-                        !empty($this->syncStatus);
+        $divisionSync = $this->isEntitySyncIsInProgress($this->syncStatus);
 
         // Return true if either sync is in progress
         return $legalEntitySync || $divisionSync;
@@ -128,6 +131,18 @@ class DivisionIndex extends DivisionComponent
 
         $user = Auth::user();
         $token = session()->get(config('ehealth.api.oauth.bearer_token'));
+
+        // Try to resume previous sync if it was paused or failed
+        if ($this->syncStatus === JobStatus::PAUSED->value || $this->syncStatus === JobStatus::FAILED->value) {
+
+            $this->resumeSynchronization($user, $token);
+
+            Session::flash('success', __('Відновлення попередньої синхронізації розпочато'));
+
+            $user->notify(new SyncNotification('division', 'resumed'));
+
+            return;
+        }
 
         // Try to resume if previous batch failed or was paused
         if ($this->syncStatus === JobStatus::FAILED->value || $this->syncStatus === JobStatus::PAUSED->value) {
@@ -197,7 +212,40 @@ class DivisionIndex extends DivisionComponent
 
                 session()->flash('success', __('Синхронізація запущена у фоновому режимі'));
         } else {
+            legalEntity()?->setEntityStatus(JobStatus::COMPLETED, LegalEntity::ENTITY_DIVISION);
+
             session()->flash('success', __('Інформацію успішно оновлено'));
+        }
+    }
+
+
+    /**
+     * Resume the synchronization process for a user with the provided token.
+     *
+     * This method handles the continuation of a previously initiated synchronization
+     * operation for a specific user using an authentication or session token.
+     *
+     * @param User $user The user instance for whom synchronization should be resumed
+     * @param string $token The authentication or session token used to resume the sync process
+     * @return void
+     */
+    protected function resumeSynchronization(User $user, string $token): void
+    {
+        $encryptedToken = Crypt::encryptString($token);
+
+        // Find all the Divisions failed batches for this legal entity and retry them
+        $failedBatches = $this->findFailedBatchesByLegalEntity(legalEntity()->id, 'ASC');
+
+        foreach ($failedBatches as $batch) {
+            if ($batch->name === self::BATCH_NAME) {
+                Log::info('Resuming Division sync batch: ' . $batch->name . ' id: ' . $batch->id);
+
+                legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_DIVISION);
+
+                $this->restartBatch($batch, $user, $encryptedToken, legalEntity());
+
+                break;
+            }
         }
     }
 

--- a/app/Livewire/Division/HealthcareService/HealthcareServiceIndex.php
+++ b/app/Livewire/Division/HealthcareService/HealthcareServiceIndex.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Livewire\Division\HealthcareService;
 
+use Exception;
+use Throwable;
 use App\Classes\eHealth\EHealth;
 use App\Enums\JobStatus;
 use App\Enums\Status;
@@ -13,10 +15,11 @@ use App\Jobs\HealthcareServiceSync;
 use App\Models\Division;
 use App\Models\HealthcareService;
 use App\Models\LegalEntity;
+use App\Models\User;
 use App\Notifications\SyncNotification;
 use App\Repositories\Repository;
+use App\Traits\BatchLegalEntityQueries;
 use App\Traits\FormTrait;
-use Exception;
 use Illuminate\Bus\Batch;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -30,18 +33,27 @@ use Livewire\Attributes\Computed;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
-use Throwable;
 
 class HealthcareServiceIndex extends Component
 {
-    use WithPagination;
-    use FormTrait;
+    use BatchLegalEntityQueries,
+        WithPagination,
+        FormTrait;
+
+    protected const string BATCH_NAME = 'HealthcareServiceSync';
 
     public ?int $divisionId = null;
 
     public ?string $divisionUuid = null;
 
     public ?Status $divisionStatus;
+
+    /**
+     * Represents the current synchronization status for the component.
+     *
+     * @var string
+     */
+    public string $syncStatus = '';
 
     #[Url(as: 'type')]
     public ?string $typeFilter = null;
@@ -67,6 +79,16 @@ class HealthcareServiceIndex extends Component
     }
 
     /**
+     * Get the current synchronization status
+     *
+     * @return string The synchronization status
+     */
+    protected function getSyncStatus(): string
+    {
+        return legalEntity()?->getEntityStatus(LegalEntity::ENTITY_HEALTHCARE_SERVICE) ?? '';
+    }
+
+    /**
      * Determine if a synchronization process is currently running.
      *
      * @return bool True if a sync process is actively processing, false otherwise.
@@ -76,25 +98,23 @@ class HealthcareServiceIndex extends Component
         // Get the sync status for whole Legal Entity
         $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
 
+        // Get the sync status only for Healthcare Service
+        $this->syncStatus = $this->getSyncStatus();
+
         // Get the sync status only for Division
         $divisionSyncStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_DIVISION);
 
         // Determine if either the Legal Entity's sync is in progress
-        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::FAILED->value && $legalEntitySyncStatus !== JobStatus::COMPLETED->value && ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+        $legalEntitySync = $this->isEntitySyncIsInProgress($legalEntitySyncStatus, true);
 
         // Determine if either the Division's sync is in progress
-        $divisionSync = $divisionSyncStatus !== JobStatus::COMPLETED->value && ($divisionSyncStatus !== JobStatus::PAUSED->value && !empty($divisionSyncStatus));
+        $divisionSync = $divisionSyncStatus !== JobStatus::COMPLETED->value;
 
-        // Get the sync status only for Division
-        $hcsSyncStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_HEALTHCARE_SERVICE);
-
-        // Determine if either the Division's sync is in progress
-        $hcsSync = $hcsSyncStatus !== JobStatus::COMPLETED->value && ($hcsSyncStatus !== JobStatus::PAUSED->value && !empty($hcsSyncStatus));
-
-        $isDivisionsPresent = Division::all()->isNotEmpty();
+        // Determine if either the Healthcare Service's sync is in progress
+        $hcsSync = $this->isEntitySyncIsInProgress($this->syncStatus);
 
         // Return true if either sync is in progress
-        return $legalEntitySync || $divisionSync || !$isDivisionsPresent || $hcsSync;
+        return $legalEntitySync || $divisionSync || $hcsSync;
     }
 
     public function boot(): void
@@ -113,6 +133,9 @@ class HealthcareServiceIndex extends Component
         $this->divisions = $legalEntity->divisions()->get(['id', 'name', 'status'])->toArray();
 
         $this->getDictionary();
+
+        // Get the sync status only for Healthcare Service
+        $this->syncStatus = $this->getSyncStatus();
     }
 
     public function search(): void
@@ -240,6 +263,21 @@ class HealthcareServiceIndex extends Component
             return;
         }
 
+        $token = Session::get(config('ehealth.api.oauth.bearer_token'));
+        $user = Auth::user();
+
+        // Try to resume previous sync if it was paused or failed
+        if ($this->syncStatus === JobStatus::PAUSED->value || $this->syncStatus === JobStatus::FAILED->value) {
+
+            $this->resumeSynchronization($user, $token);
+
+            Session::flash('success', __('Відновлення попередньої синхронізації розпочато'));
+
+            $user->notify(new SyncNotification('healthcare_service', 'resumed'));
+
+            return;
+        }
+
         try {
             $query = $this->divisionUuid ? ['division_id' => $this->divisionUuid] : [];
 
@@ -269,16 +307,48 @@ class HealthcareServiceIndex extends Component
         // If there are more pages, dispatch a job to handle the rest
         if ($response->isNotLast()) {
             try {
-                Auth::user()->notify(new SyncNotification('healthcare_service', 'started'));
-                $this->dispatchNextSyncJobs();
+                $user->notify(new SyncNotification('healthcare_service', 'started'));
+                $this->dispatchNextSyncJobs($user, $token);
                 Session::flash('success', __('Синхронізацію успішно розпочато.'));
             } catch (Throwable $exception) {
                 Log::error('Failed to dispatch HealthcareServiceSync batch', ['exception' => $exception]);
 
-                Auth::user()->notify(new SyncNotification('healthcare_service', 'failed'));
+                $user->notify(new SyncNotification('healthcare_service', 'failed'));
             }
         } else {
+            legalEntity()?->setEntityStatus(JobStatus::COMPLETED, LegalEntity::ENTITY_HEALTHCARE_SERVICE);
+
             Session::flash('success', __('Інформацію успішно оновлено'));
+        }
+    }
+
+     /**
+     * Resume the synchronization process for a user with the provided token.
+     *
+     * This method handles the continuation of a previously initiated synchronization
+     * operation for a specific user using an authentication or session token.
+     *
+     * @param User $user The user instance for whom synchronization should be resumed
+     * @param string $token The authentication or session token used to resume the sync process
+     * @return void
+     */
+    protected function resumeSynchronization(User $user, string $token): void
+    {
+        $encryptedToken = Crypt::encryptString($token);
+
+        // Find all the Divisions failed batches for this legal entity and retry them
+        $failedBatches = $this->findFailedBatchesByLegalEntity(legalEntity()->id, 'ASC');
+
+        foreach ($failedBatches as $batch) {
+            if ($batch->name === self::BATCH_NAME) {
+                Log::info('Resuming Division sync batch: ' . $batch->name . ' id: ' . $batch->id);
+
+                legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_HEALTHCARE_SERVICE);
+
+                $this->restartBatch($batch, $user, $encryptedToken, legalEntity());
+
+                break;
+            }
         }
     }
 
@@ -311,13 +381,10 @@ class HealthcareServiceIndex extends Component
      * @return void
      * @throws Throwable
      */
-    protected function dispatchNextSyncJobs(): void
+    protected function dispatchNextSyncJobs(User $user, string $token): void
     {
-        $token = Session::get(config('ehealth.api.oauth.bearer_token'));
-        $user = Auth::user();
-
         Bus::batch([new HealthcareServiceSync(legalEntity(), page: 2)])
-            ->withOption('division_id', $this->divisionUuid)
+            ->withOption('legal_entity_id', legalEntity()->id)
             ->withOption('token', Crypt::encryptString($token))
             ->withOption('user', $user)
             ->then(fn () => $user->notify(new SyncNotification('healthcare_service', 'completed')))
@@ -330,7 +397,7 @@ class HealthcareServiceIndex extends Component
                 $user->notify(new SyncNotification('healthcare_service', 'failed'));
             })
             ->onQueue('sync')
-            ->name('HealthcareServiceSync')
+            ->name(self::BATCH_NAME)
             ->dispatch();
 
             legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_HEALTHCARE_SERVICE);

--- a/app/Livewire/Employee/EmployeeIndex.php
+++ b/app/Livewire/Employee/EmployeeIndex.php
@@ -14,6 +14,7 @@ use App\Jobs\EmployeeSync;
 use App\Models\Employee\Employee;
 use App\Models\Employee\EmployeeRequest;
 use App\Models\LegalEntity;
+use App\Models\User;
 use App\Notifications\EmployeeSyncCompleted;
 use App\Notifications\SyncNotification;
 use App\Repositories\Repository;
@@ -39,8 +40,11 @@ use Throwable;
 #[AllowDynamicProperties]
 class EmployeeIndex extends EmployeeComponent
 {
-    use WithPagination;
-    use BatchLegalEntityQueries;
+    use WithPagination,
+        BatchLegalEntityQueries;
+
+    protected const string BATCH_NAME = 'EmployeeFullSync';
+    protected const string DEPENDENT_BATCH_NAME = 'EmployeeDetailsSync';
 
     // --- Component State for Filters ---
     public string $search = '';
@@ -73,10 +77,27 @@ class EmployeeIndex extends EmployeeComponent
 
     private LegalEntity $legalEntity;
 
-    #[Computed]
+    /**
+     * Represents the current synchronization status for the component.
+     *
+     * @var string
+     */
+    public string $syncStatus = '';
+
+   #[Computed]
     public function isSync(): bool
     {
         return $this->isSyncProcessing();
+    }
+
+    /**
+     * Get the synchronization status of the employee request.
+     *
+     * @return string The current sync status
+     */
+    protected function getSyncStatus(): string
+    {
+        return legalEntity()?->getEntityStatus(LegalEntity::ENTITY_EMPLOYEE) ?? '';
     }
 
     /**
@@ -89,14 +110,14 @@ class EmployeeIndex extends EmployeeComponent
         // Get the sync status for whole Legal Entity
         $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
 
-        // Get the sync status only for Division
-        $employeeSyncStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_EMPLOYEE);
+        // Set the sync status only for Employee
+        $this->syncStatus = $this->getSyncStatus();
 
         // Determine if either the Legal Entity's sync is in progress
-        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::COMPLETED->value && ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+        $legalEntitySync = $this->isEntitySyncIsInProgress($legalEntitySyncStatus, true);
 
         // Determine if either the Division's sync is in progress
-        $employeeSync = $employeeSyncStatus !== JobStatus::COMPLETED->value && ($employeeSyncStatus !== JobStatus::PAUSED->value && !empty($employeeSyncStatus));
+        $employeeSync = $this->isEntitySyncIsInProgress($this->syncStatus);
 
         // Return true if either sync is in progress
         return $legalEntitySync || $employeeSync;
@@ -113,8 +134,13 @@ class EmployeeIndex extends EmployeeComponent
     public function mount(LegalEntity $legalEntity): void
     {
         $this->legalEntity = $legalEntity;
+
         $this->loadDivisions($legalEntity);
+
         $this->loadDictionaries();
+
+        // Set the sync status for Employee
+        $this->syncStatus = $this->getSyncStatus();
     }
 
     public function applyFilters(): void
@@ -328,6 +354,18 @@ class EmployeeIndex extends EmployeeComponent
         }
 
         $user = Auth::user();
+        $token = session()->get(config('ehealth.api.oauth.bearer_token'));
+
+        // Try to resume previous sync if it was paused or failed
+        if ($this->syncStatus === JobStatus::PAUSED->value || $this->syncStatus === JobStatus::FAILED->value) {
+
+            $this->resumeSynchronization($user, $token);
+
+            $user->notify(new SyncNotification('employee', 'resumed'));
+
+            return;
+        }
+
         $user->notify(new SyncNotification('employee', 'started'));
 
         $this->dispatch('flashMessage', [
@@ -374,8 +412,6 @@ class EmployeeIndex extends EmployeeComponent
 
         Employee::upsert($employees, uniqueBy: ['uuid']);
 
-        $token = session()->get(config('ehealth.api.oauth.bearer_token'));
-
         if ($response->isNotLast()) {
             Bus::batch([
                 new EmployeeSync(
@@ -400,7 +436,7 @@ class EmployeeIndex extends EmployeeComponent
                     $user->notify(new EmployeeSyncCompleted($message, 'error'));
                 })
                 ->onQueue('sync')
-                ->name('Employee Full Sync')
+                ->name(self::BATCH_NAME)
                 ->dispatch();
         } else {
             Bus::batch($this->getEmployeeDetailsStartJob($this->legalEntity, null))
@@ -419,7 +455,7 @@ class EmployeeIndex extends EmployeeComponent
                     $user->notify(new EmployeeSyncCompleted($message, 'error'));
                 })
                 ->onQueue('sync')
-                ->name('Employee Full Sync')
+                ->name(self::DEPENDENT_BATCH_NAME)
                 ->dispatch();
         }
 
@@ -429,6 +465,41 @@ class EmployeeIndex extends EmployeeComponent
             'message' => "Сторінка 1 оброблена. Решта завантажується фоново.",
             'type' => 'success'
         ]);
+    }
+
+    /**
+     * Resume the synchronization process for a user with the provided token.
+     *
+     * This method handles the continuation of a previously initiated synchronization
+     * operation for a specific user using an authentication or session token.
+     *
+     * @param User $user The user instance for whom synchronization should be resumed
+     * @param string $token The authentication or session token used to resume the sync process
+     * @return void
+     */
+    protected function resumeSynchronization(User $user, string $token): void
+    {
+        $encryptedToken = Crypt::encryptString($token);
+
+        // Find all the EmployeeRequests failed batches for this legal entity and retry them
+        $failedBatches = $this->findFailedBatchesByLegalEntity(legalEntity()->id, 'ASC');
+
+        foreach ($failedBatches as $batch) {
+            if ($batch->name === self::BATCH_NAME || $batch->name === self::DEPENDENT_BATCH_NAME) {
+                Log::info('Resuming Employee sync batch: ' . $batch->name . ' id: ' . $batch->id);
+
+                legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_EMPLOYEE);
+
+                $this->restartBatch($batch, $user, $encryptedToken, legalEntity());
+
+                $this->dispatch('flashMessage', [
+                    'message' => __('Відновлення попередньої синхронізації розпочато'),
+                    'type' => 'success'
+                ]);
+
+                break;
+            }
+        }
     }
 
     /**

--- a/app/Livewire/EmployeeRequest/EmployeeRequestIndex.php
+++ b/app/Livewire/EmployeeRequest/EmployeeRequestIndex.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\EmployeeRequest;
 
 use Auth;
+use App\Models\User;
 use App\Enums\JobStatus;
 use Illuminate\Bus\Batch;
 use App\Models\LegalEntity;
@@ -25,14 +26,15 @@ use Illuminate\Http\Client\ConnectionException;
 use App\Notifications\EmployeeRequestSyncCompleted;
 use App\Services\Employee\EmployeeRequestProcessor;
 use App\Exceptions\EHealth\EHealthResponseException;
+use App\Notifications\SyncNotification;
 
 class EmployeeRequestIndex extends EmployeeComponent
 {
     use WithPagination,
         BatchLegalEntityQueries;
 
-    protected const string BATCH_NAME = 'EmployeeRequest Full Sync';
-    protected const string SUB_BATCH_NAME = 'EmployeeRequestRequests Full Sync';
+    protected const string BATCH_NAME = 'EmployeeRequestsSyncAll';
+    protected const string DEPENDENT_BATCH_NAME = 'EmployeeRequestDetailsSync';
 
     public string $search = '';
     public string $status = '';
@@ -69,23 +71,14 @@ class EmployeeRequestIndex extends EmployeeComponent
      */
     protected function isSyncProcessing(): bool
     {
-        // Get the sync status for whole Legal Entity
-        $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
-
         // Set the sync status only for EmployeeRequest
         $this->syncStatus = $this->getSyncStatus();
 
-        // Determine if either the Legal Entity's sync is in progress
-        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::COMPLETED->value && ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
-
         // Determine if either the EmployeeRequest's sync is in progress
-        $employeeRequestSync = $this->syncStatus !== JobStatus::COMPLETED->value &&
-                               $this->syncStatus !== JobStatus::PAUSED->value &&
-                               $this->syncStatus !== JobStatus::FAILED->value &&
-                               !empty($this->syncStatus);
+        $employeeRequestSync = $this->isEntitySyncIsInProgress($this->syncStatus);
 
         // Return true if either sync is in progress
-        return $legalEntitySync || $employeeRequestSync;
+        return $employeeRequestSync;
     }
 
     public function boot(): void
@@ -194,13 +187,23 @@ class EmployeeRequestIndex extends EmployeeComponent
         }
 
         if ($this->isSyncProcessing()) {
-            Session::flash('error', 'Синхронізація вже запущена. Будь ласка, зачекайте її завершення.');
+            Session::flash('error', __('Синхронізація вже запущена. Будь ласка, зачекайте її завершення.'));
 
             return;
         }
 
         $user = Auth::user();
         $token = session()->get(config('ehealth.api.oauth.bearer_token'));
+
+        // Try to resume previous sync if it was paused or failed
+        if ($this->syncStatus === JobStatus::PAUSED->value || $this->syncStatus === JobStatus::FAILED->value) {
+
+            $this->resumeSynchronization($user, $token);
+
+            $user->notify(new SyncNotification('employee_request', 'resumed'));
+
+            return;
+        }
 
         // Notify start
         $this->dispatch('flashMessage', [
@@ -235,7 +238,6 @@ class EmployeeRequestIndex extends EmployeeComponent
 
         // 3. Check if there are more pages
         if ($response->isNotLast()) {
-
             Bus::batch([
                 new EmployeeRequestsSyncAll(
                     legalEntity: $this->legalEntity,
@@ -278,7 +280,7 @@ class EmployeeRequestIndex extends EmployeeComponent
                     $user->notify(new EmployeeRequestSyncCompleted($message, 'error'));
                 })
                 ->onQueue('sync')
-                ->name(self::SUB_BATCH_NAME)
+                ->name(self::DEPENDENT_BATCH_NAME)
                 ->dispatch();
         }
 
@@ -291,6 +293,44 @@ class EmployeeRequestIndex extends EmployeeComponent
 
         // Force refresh of the table
         $this->resetPage();
+    }
+
+    /**
+     * Resume the synchronization process for a user with the provided token.
+     *
+     * This method handles the continuation of a previously initiated synchronization
+     * operation for a specific user using an authentication or session token.
+     *
+     * @param User $user The user instance for whom synchronization should be resumed
+     * @param string $token The authentication or session token used to resume the sync process
+     * @return void
+     */
+    protected function resumeSynchronization(User $user, string $token): void
+    {
+        $encryptedToken = Crypt::encryptString($token);
+
+        // Define the daily sync batch name (created by EmployeeRequestsSyncAll listener)
+        $dailySyncName = 'Full Employee Requests Sync for LE: ' . legalEntity()->id;
+
+        // Find all the EmployeeRequests failed batches for this legal entity and retry them
+        $failedBatches = $this->findFailedBatchesByLegalEntity(legalEntity()->id, 'ASC');
+
+        foreach ($failedBatches as $batch) {
+            if ($batch->name === self::BATCH_NAME || $batch->name === self::DEPENDENT_BATCH_NAME || $batch->name === $dailySyncName) {
+                Log::info('Resuming EmployeeRequest sync batch: ' . $batch->name . ' id: ' . $batch->id);
+
+                legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_EMPLOYEE_REQUEST);
+
+                $this->restartBatch($batch, $user, $encryptedToken, legalEntity());
+
+                $this->dispatch('flashMessage', [
+                    'message' => __('Відновлення попередньої синхронізації розпочато'),
+                    'type' => 'success'
+                ]);
+
+                break;
+            }
+        }
     }
 
     /**

--- a/app/Livewire/EmployeeRole/EmployeeRoleIndex.php
+++ b/app/Livewire/EmployeeRole/EmployeeRoleIndex.php
@@ -4,34 +4,37 @@ declare(strict_types=1);
 
 namespace App\Livewire\EmployeeRole;
 
+use Throwable;
+use App\Models\User;
+use Livewire\Component;
 use App\Enums\JobStatus;
-use App\Classes\eHealth\EHealth;
-use App\Exceptions\EHealth\EHealthResponseException;
-use App\Exceptions\EHealth\EHealthValidationException;
-use App\Jobs\EmployeeRoleSync;
-use App\Models\EmployeeRole;
-use App\Models\LegalEntity;
-use App\Notifications\SyncNotification;
-use App\Repositories\Repository;
 use App\Traits\FormTrait;
 use Illuminate\Bus\Batch;
+use Illuminate\View\View;
+use App\Models\LegalEntity;
+use App\Models\EmployeeRole;
+use Livewire\WithPagination;
+use App\Jobs\EmployeeRoleSync;
+use App\Repositories\Repository;
+use App\Classes\eHealth\EHealth;
+use Livewire\Attributes\Computed;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Session;
+use App\Traits\BatchLegalEntityQueries;
+use App\Notifications\SyncNotification;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Crypt;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Session;
-use Illuminate\View\View;
-use Livewire\Attributes\Computed;
-use Livewire\Component;
-use Livewire\WithPagination;
-use Throwable;
+use App\Exceptions\EHealth\EHealthResponseException;
+use App\Exceptions\EHealth\EHealthValidationException;
 
 class EmployeeRoleIndex extends Component
 {
-    use WithPagination;
-    use FormTrait;
+    use BatchLegalEntityQueries,
+        WithPagination,
+        FormTrait;
 
     protected const string BATCH_NAME = 'EmployeeRoleSync';
 
@@ -104,14 +107,10 @@ class EmployeeRoleIndex extends Component
         $this->syncStatus = $this->getSyncStatus();
 
         // Determine if either the Legal Entity's sync is in progress
-        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::COMPLETED->value &&
-                           ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+        $legalEntitySync = $this->isEntitySyncIsInProgress($legalEntitySyncStatus, true);
 
         // Determine if either the Employee Role's sync is in progress
-        $employeeRoleSync = $this->syncStatus !== JobStatus::COMPLETED->value &&
-                               $this->syncStatus !== JobStatus::PAUSED->value &&
-                               $this->syncStatus !== JobStatus::FAILED->value &&
-                               !empty($this->syncStatus);
+        $employeeRoleSync = $this->isEntitySyncIsInProgress($this->syncStatus);
 
         // Return true if either sync is in progress
         return $legalEntitySync || $employeeRoleSync;
@@ -128,6 +127,8 @@ class EmployeeRoleIndex extends Component
         $this->getDictionary();
 
         $this->healthcareServiceSpecialityTypes = array_keys($this->dictionaries['SPECIALITY_TYPE']);
+
+        $this->syncStatus = $this->getSyncStatus();
     }
 
     public function applyFilters(): void
@@ -198,6 +199,20 @@ class EmployeeRoleIndex extends Component
             return;
         }
 
+        $user = Auth::user();
+        $token = Session::get(config('ehealth.api.oauth.bearer_token'));
+
+        if ($this->syncStatus === JobStatus::PAUSED->value || $this->syncStatus === JobStatus::FAILED->value) {
+
+            $this->resumeSynchronization($user, $token);
+
+            Session::flash('success', __('Відновлення попередньої синхронізації розпочато'));
+
+            $user->notify(new SyncNotification('employee_role', 'resumed'));
+
+            return;
+        }
+
         try {
             $response = EHealth::employeeRole()->getMany();
         } catch (ConnectionException $exception) {
@@ -213,7 +228,8 @@ class EmployeeRoleIndex extends Component
         }
 
         try {
-            $validated = $response->validate();
+            $validated = $this->normalizeDate($response->validate());
+
             Repository::employeeRole()->sync($response->map($validated));
         } catch (Throwable $exception) {
             Session::flash('error', 'Виникла помилка. Оновіть список співробітників і послуги та спробуйте ще раз');
@@ -226,7 +242,7 @@ class EmployeeRoleIndex extends Component
         if ($response->isNotLast()) {
             try {
                 Auth::user()->notify(new SyncNotification('employee_role', 'started'));
-                $this->dispatchNextSyncJobs();
+                $this->dispatchNextSyncJobs($user, $token);
                 Session::flash('success', __('Синхронізацію успішно розпочато.'));
             } catch (Throwable $exception) {
                 Log::error('Failed to dispatch EmployeeRole batch', ['exception' => $exception]);
@@ -234,6 +250,8 @@ class EmployeeRoleIndex extends Component
                 Auth::user()->notify(new SyncNotification('employee_role', 'failed'));
             }
         } else {
+            legalEntity()?->setEntityStatus(JobStatus::COMPLETED, LegalEntity::ENTITY_EMPLOYEE_ROLE);
+
             Session::flash('success', __('Інформацію успішно оновлено'));
         }
     }
@@ -249,17 +267,45 @@ class EmployeeRoleIndex extends Component
     }
 
     /**
+     * Resume the synchronization process for a user with the provided token.
+     *
+     * This method handles the continuation of a previously initiated synchronization
+     * operation for a specific user using an authentication or session token.
+     *
+     * @param User $user The user instance for whom synchronization should be resumed
+     * @param string $token The authentication or session token used to resume the sync process
+     * @return void
+     */
+    protected function resumeSynchronization(User $user, string $token): void
+    {
+        $encryptedToken = Crypt::encryptString($token);
+
+        // Find all the EmployeeRoles failed batches for this legal entity and retry them
+        $failedBatches = $this->findFailedBatchesByLegalEntity(legalEntity()->id, 'ASC');
+
+        foreach ($failedBatches as $batch) {
+            if ($batch->name === self::BATCH_NAME) {
+                Log::info('Resuming Employee sync batch: ' . $batch->name . ' id: ' . $batch->id);
+
+                legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_EMPLOYEE_ROLE);
+
+                $this->restartBatch($batch, $user, $encryptedToken, legalEntity());
+
+                break;
+            }
+        }
+    }
+
+    /**
      * Dispatch next sync jobs for remaining pages.
      *
      * @return void
      * @throws Throwable
      */
-    protected function dispatchNextSyncJobs(): void
+    protected function dispatchNextSyncJobs(User $user, string $token): void
     {
-        $token = Session::get(config('ehealth.api.oauth.bearer_token'));
-        $user = Auth::user();
-
         Bus::batch([new EmployeeRoleSync(legalEntity(), page: 2)])
+            ->withOption('legal_entity_id', legalEntity()->id)
             ->withOption('token', Crypt::encryptString($token))
             ->withOption('user', $user)
             ->then(fn () => $user->notify(new SyncNotification('employee_role', 'completed')))

--- a/app/Livewire/Equipment/EquipmentIndex.php
+++ b/app/Livewire/Equipment/EquipmentIndex.php
@@ -14,8 +14,11 @@ use App\Jobs\EquipmentSync;
 use App\Livewire\Equipment\Traits\StatusTrait;
 use App\Models\Equipment;
 use App\Models\LegalEntity;
+use App\Models\User;
 use App\Notifications\SyncNotification;
 use App\Repositories\Repository;
+use App\Traits\BatchLegalEntityQueries;
+use App\Traits\FormTrait;
 use Illuminate\Bus\Batch;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Client\ConnectionException;
@@ -33,8 +36,10 @@ use Throwable;
 
 class EquipmentIndex extends Component
 {
-    use WithPagination;
-    use StatusTrait;
+    use BatchLegalEntityQueries,
+        WithPagination,
+        StatusTrait,
+        FormTrait;
 
     protected const string BATCH_NAME = 'EquipmentSync';
 
@@ -121,17 +126,35 @@ class EquipmentIndex extends Component
         $this->syncStatus = $this->getSyncStatus();
 
         // Determine if either the Legal Entity's sync is in progress
-        $legalEntitySync = $legalEntitySyncStatus !== JobStatus::COMPLETED->value &&
-                           ($legalEntitySyncStatus !== JobStatus::PAUSED->value && !empty($legalEntitySyncStatus));
+        $legalEntitySync = $this->isEntitySyncIsInProgress($legalEntitySyncStatus, true);
+
+        // Get the sync status only for Division
+        $divisionSyncStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_DIVISION);
+
+        // Get the sync status only for HealthCare Service
+        $healthCareServiceSyncStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_HEALTHCARE_SERVICE);
+
+        // Get the sync status only for HealthCare Service
+        $employeeSyncStatus = legalEntity()?->getEntityStatus(LegalEntity::ENTITY_EMPLOYEE);
 
         // Determine if either the Equipment's sync is in progress
-        $equipmentSync = $this->syncStatus !== JobStatus::COMPLETED->value &&
-                               $this->syncStatus !== JobStatus::PAUSED->value &&
-                               $this->syncStatus !== JobStatus::FAILED->value &&
-                               !empty($this->syncStatus);
+        $equipmentSync = $this->isEntitySyncIsInProgress($this->syncStatus);
+
+        // Determine if either the Division's sync is in progress
+        $divisionSync = $divisionSyncStatus !== JobStatus::COMPLETED->value;
+
+        // Determine if either the HealthCare Service's sync is in progress
+        $healthCareServiceSync = $healthCareServiceSyncStatus !== JobStatus::COMPLETED->value;
+
+        // Determine if either the Employee's sync is in progress
+        $employeeSync = $employeeSyncStatus !== JobStatus::COMPLETED->value;
 
         // Return true if either sync is in progress
-        return $legalEntitySync || $equipmentSync;
+        return $equipmentSync ||
+               $legalEntitySync ||
+               $divisionSync ||
+               $healthCareServiceSync ||
+               $employeeSync;;
     }
 
     public function boot(): void
@@ -176,6 +199,21 @@ class EquipmentIndex extends Component
             return;
         }
 
+        $user = Auth::user();
+        $token = Session::get(config('ehealth.api.oauth.bearer_token'));
+
+        // Try to resume previous sync if it was paused or failed
+        if ($this->syncStatus === JobStatus::PAUSED->value || $this->syncStatus === JobStatus::FAILED->value) {
+
+            $this->resumeSynchronization($user, $token);
+
+            Session::flash('success', __('Відновлення попередньої синхронізації розпочато'));
+
+            $user->notify(new SyncNotification('equipment', 'resumed'));
+
+            return;
+        }
+
         try {
             $response = EHealth::equipment()->getMany();
         } catch (ConnectionException $exception) {
@@ -196,7 +234,8 @@ class EquipmentIndex extends Component
         }
 
         try {
-            $validated = $response->validate();
+            $validated = $this->normalizeDate($response->validate());
+
             Repository::equipment()->sync($response->map($validated));
         } catch (Throwable $exception) {
             Session::flash('error', 'Виникла помилка. Оновіть список місць надання послуг та співробітників і спробуйте ще раз');
@@ -208,16 +247,48 @@ class EquipmentIndex extends Component
         // If there are more pages, dispatch a job to handle the rest
         if ($response->isNotLast()) {
             try {
-                Auth::user()->notify(new SyncNotification('equipment', 'started'));
-                $this->dispatchNextSyncJobs();
+                $user->notify(new SyncNotification('equipment', 'started'));
+                $this->dispatchNextSyncJobs($user, $token);
                 Session::flash('success', __('forms.success.sync_started'));
             } catch (Throwable $exception) {
                 Log::error('Failed to dispatch EquipmentSync batch', ['exception' => $exception]);
 
-                Auth::user()->notify(new SyncNotification('equipment', 'failed'));
+                $user->notify(new SyncNotification('equipment', 'failed'));
             }
         } else {
+            legalEntity()?->setEntityStatus(JobStatus::COMPLETED, LegalEntity::ENTITY_EQUIPMENT);
+
             Session::flash('success', __('forms.success.updated'));
+        }
+    }
+
+    /**
+     * Resume the synchronization process for a user with the provided token.
+     *
+     * This method handles the continuation of a previously initiated synchronization
+     * operation for a specific user using an authentication or session token.
+     *
+     * @param User $user The user instance for whom synchronization should be resumed
+     * @param string $token The authentication or session token used to resume the sync process
+     * @return void
+     */
+    protected function resumeSynchronization(User $user, string $token): void
+    {
+        $encryptedToken = Crypt::encryptString($token);
+
+        // Find all the Equipment's failed batches for this legal entity and retry them
+        $failedBatches = $this->findFailedBatchesByLegalEntity(legalEntity()->id, 'ASC');
+
+        foreach ($failedBatches as $batch) {
+            if ($batch->name === self::BATCH_NAME) {
+                Log::info('Resuming Equipment sync batch: ' . $batch->name . ' id: ' . $batch->id);
+
+                legalEntity()?->setEntityStatus(JobStatus::PROCESSING, LegalEntity::ENTITY_EQUIPMENT);
+
+                $this->restartBatch($batch, $user, $encryptedToken, legalEntity());
+
+                break;
+            }
         }
     }
 
@@ -265,12 +336,10 @@ class EquipmentIndex extends Component
      * @return void
      * @throws Throwable
      */
-    protected function dispatchNextSyncJobs(): void
+    protected function dispatchNextSyncJobs(User $user, string $token): void
     {
-        $token = Session::get(config('ehealth.api.oauth.bearer_token'));
-        $user = Auth::user();
-
         Bus::batch([new EquipmentSync(legalEntity(), page: 2)])
+            ->withOption('legal_entity_id', legalEntity()->id)
             ->withOption('token', Crypt::encryptString($token))
             ->withOption('user', $user)
             ->then(fn () => $user->notify(new SyncNotification('equipment', 'completed')))

--- a/app/Livewire/LegalEntity/LegalEntity.php
+++ b/app/Livewire/LegalEntity/LegalEntity.php
@@ -832,6 +832,15 @@ abstract class LegalEntity extends Component
         // Do unset this because it already set if create or present and deny to modify if edit
         unset($data['data']['license']);
 
+        // Normalize date fields (need for MySQL date format)
+        if (isset($data['data']['inserted_at'])) {
+            $data['data']['inserted_at'] = convertToYmd($data['data']['inserted_at']);
+        }
+
+        if (isset($data['data']['updated_at'])) {
+            $data['data']['updated_at'] = convertToYmd($data['data']['updated_at']);
+        }
+
         try {
             // Find or create a new LegalEntity object by UUID
             $this->legalEntity = LegalEntityModel::firstOrNew(['uuid' => $uuid]);
@@ -926,6 +935,9 @@ abstract class LegalEntity extends Component
      */
     protected function saveLicense(array $data): void
     {
+        $data['ehealth_inserted_at'] = convertToYmd($data['ehealth_inserted_at']);
+        $data['ehealth_updated_at'] = convertToYmd($data['ehealth_updated_at']);
+
         $license = License::firstOrNew(['uuid' => $data['uuid']]);
         $license->fill($data);
         $license->is_primary = true;

--- a/app/Livewire/LegalEntity/LegalEntityDetails.php
+++ b/app/Livewire/LegalEntity/LegalEntityDetails.php
@@ -4,14 +4,20 @@ namespace App\Livewire\LegalEntity;
 
 use Arr;
 use Throwable;
+use App\Models\User;
 use App\Enums\JobStatus;
+use App\Traits\FormTrait;
 use App\Models\LegalEntity;
 use App\Classes\eHealth\EHealth;
 use Livewire\Attributes\Computed;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Crypt;
 use App\Repositories\PhoneRepository;
+use App\Notifications\SyncNotification;
+use Illuminate\Support\Facades\Session;
 use App\Repositories\AddressRepository;
+use App\Traits\BatchLegalEntityQueries;
 use Spatie\Permission\PermissionRegistrar;
 use App\Exceptions\EHealth\EHealthResponseException;
 use App\Exceptions\EHealth\EHealthValidationException;
@@ -19,6 +25,11 @@ use App\Livewire\LegalEntity\LegalEntity as LegalEntityComponent;
 
 class LegalEntityDetails extends LegalEntityComponent
 {
+    use BatchLegalEntityQueries,
+        FormTrait;
+
+    protected const string BATCH_NAME = 'FirstLoginSync';
+
     public array $edrStatuses = [];
 
     public array $edrLegalForms = [];
@@ -26,6 +37,23 @@ class LegalEntityDetails extends LegalEntityComponent
     public array $mainKVED = [];
 
     public array $additionalKVEDs = [];
+
+    /**
+     * Represents the current synchronization status for the component.
+     *
+     * @var string
+     */
+    public string $syncStatus = '';
+
+    /**
+     * Get the synchronization status of the declarations
+     *
+     * @return string The current sync status
+     */
+    protected function getSyncStatus(): string
+    {
+        return legalEntity()?->getEntityStatus() ?? '';
+    }
 
     #[Computed]
     public function isSync(): bool
@@ -41,13 +69,10 @@ class LegalEntityDetails extends LegalEntityComponent
     protected function isSyncProcessing(): bool
     {
         // Get the sync status for whole Legal Entity
-        $legalEntitySyncStatus = legalEntity()?->getEntityStatus();
+        $this->syncStatus = $this->getSyncStatus();
 
         // Determine if either the Legal Entity's sync is in progress
-        return $legalEntitySyncStatus !== JobStatus::COMPLETED->value &&
-               $legalEntitySyncStatus !== JobStatus::FAILED->value &&
-               $legalEntitySyncStatus !== JobStatus::PAUSED->value &&
-               !empty($legalEntitySyncStatus);
+        return $this->isEntitySyncIsInProgress($this->syncStatus);
     }
 
     public function boot(
@@ -73,6 +98,9 @@ class LegalEntityDetails extends LegalEntityComponent
         $this->edrLegalForms = dictionary()->getDictionary('LEGAL_FORM');
 
         $this->filterKveds();
+
+        // Get the sync status for whole Legal Entity
+        $this->syncStatus = $this->getSyncStatus();
     }
 
     /**
@@ -277,6 +305,27 @@ class LegalEntityDetails extends LegalEntityComponent
             return;
         }
 
+        if ($this->isSyncProcessing()) {
+            Session::flash('error', 'Синхронізація вже запущена. Будь ласка, зачекайте її завершення.');
+
+            return;
+        }
+
+        $user = Auth::user();
+        $token = Session::get(config('ehealth.api.oauth.bearer_token'));
+
+        // Try to resume previous sync if it was paused or failed
+        if ($this->syncStatus === JobStatus::PAUSED->value || $this->syncStatus === JobStatus::FAILED->value) {
+
+            $this->resumeSynchronization($user, $token);
+
+            Session::flash('success', __('Відновлення попередньої синхронізації розпочато'));
+
+            $user->notify(new SyncNotification('legal_entity', 'resumed'));
+
+            return;
+        }
+
         legalEntity()?->setEntityStatus(JobStatus::PROCESSING);
 
         $oldStatus = $this->legalEntity->status;
@@ -284,7 +333,7 @@ class LegalEntityDetails extends LegalEntityComponent
         try {
             $response = EHealth::legalEntity()->getDetails();
 
-            $legalEntityData = ['data' => $response->validate()];
+            $legalEntityData = $this->normalizeDate(['data' => $response->validate()]);
 
             // Set accreditation and archive to null concerns on the storda data in the DB table
             $legalEntityData = $this->filterUnprovidedFields($legalEntityData, $this->legalEntityForm->toArray());
@@ -340,6 +389,36 @@ class LegalEntityDetails extends LegalEntityComponent
         legalEntity()?->setEntityStatus(JobStatus::COMPLETED);
 
         return;
+    }
+
+     /**
+     * Resume the synchronization process for a user with the provided token.
+     *
+     * This method handles the continuation of a previously initiated synchronization
+     * operation for a specific user using an authentication or session token.
+     *
+     * @param User $user The user instance for whom synchronization should be resumed
+     * @param string $token The authentication or session token used to resume the sync process
+     * @return void
+     */
+    protected function resumeSynchronization(User $user, string $token): void
+    {
+        $encryptedToken = Crypt::encryptString($token);
+
+        // Find all the Equipment's failed batches for this legal entity and retry them
+        $failedBatches = $this->findFailedBatchesByLegalEntity(legalEntity()->id, 'ASC');
+
+        foreach ($failedBatches as $batch) {
+            if ($batch->name === self::BATCH_NAME) {
+                Log::info('Resuming Equipment sync batch: ' . $batch->name . ' id: ' . $batch->id);
+
+                legalEntity()?->setEntityStatus(JobStatus::PROCESSING);
+
+                $this->restartBatch($batch, $user, $encryptedToken, legalEntity());
+
+                break;
+            }
+        }
     }
 
     public function render()

--- a/app/Livewire/License/LicenseIndex.php
+++ b/app/Livewire/License/LicenseIndex.php
@@ -59,7 +59,7 @@ class LicenseIndex extends Component
             return;
         }
 
-        $licences = $response->validate();
+        $licences = $this->normalizeDate($response->validate());
 
         try {
             License::upsert($response->map($licences), uniqueBy: ['uuid'], update: new License()->getFillable());

--- a/app/Models/LegalEntity.php
+++ b/app/Models/LegalEntity.php
@@ -40,9 +40,8 @@ class LegalEntity extends Model
     public const string ENTITY_EMPLOYEE_ROLE = 'employee_role_';
     public const string ENTITY_EMPLOYEE_REQUEST = 'employee_request_';
     public const string ENTITY_LICENSE = 'license_';
-    public const string ENTITY_CONTRACT = 'document_';
+    public const string ENTITY_DOCUMENT = 'document_';
     public const string ENTITY_DECLARATION = 'declaration_';
-    public const string ENTITY_DECLARATION_REQUEST = 'declaration_request_';
     public const string ENTITY_EQUIPMENT = 'equipment_';
 
     protected $fillable = [

--- a/app/Traits/BatchLegalEntityQueries.php
+++ b/app/Traits/BatchLegalEntityQueries.php
@@ -32,6 +32,28 @@ use App\Jobs\DeclarationRequestDetailsSync;
 trait BatchLegalEntityQueries
 {
     /**
+     * Check if the entity in the synchronization process right now.
+     * This determines if the entity synchronization status is valid for start/continue synchronization
+     * If returns true, synchronization cannot proceed; otherwise, it can be start/continue.
+     * If returns true the sync entity button's got the "disabled" state.
+     *
+     * @param string $entityStatus The synchronization status of the entity to check
+     *
+     * @return bool Returns true if the entity sync status is valid/successful for sync, false otherwise
+     */
+    protected function isEntitySyncIsInProgress(?string $entityStatus = null, bool $isLegalEntity = false): bool
+    {
+        return $isLegalEntity
+            ?  $entityStatus !== JobStatus::COMPLETED->value
+            :  (
+               $entityStatus !== JobStatus::COMPLETED->value &&
+               $entityStatus !== JobStatus::PAUSED->value &&
+               $entityStatus !== JobStatus::FAILED->value &&
+               !empty($entityStatus)
+            );
+    }
+
+    /**
      * Find all batches for a specific legal entity
      *
      * @param int $legalEntityId

--- a/app/Traits/FormTrait.php
+++ b/app/Traits/FormTrait.php
@@ -277,4 +277,34 @@ trait FormTrait
             'line' => $exception->getLine()
         ]);
     }
+
+    /**
+     * Normalize date fields in an array (need for MySQL database)
+     *
+     * @param array $data
+     *
+     * @return array
+     */
+    protected function normalizeDate(array $data): array
+    {
+        return array_map(function ($item) {
+            if (isset($item['ehealth_inserted_at'])) {
+                $item['ehealth_inserted_at'] = convertToYmd($item['ehealth_inserted_at']);
+            }
+
+            if (isset($item['ehealth_updated_at'])) {
+                $item['ehealth_updated_at'] = convertToYmd($item['ehealth_updated_at']);
+            }
+
+            if (isset($item['end_date'])) {
+                $item['end_date'] = convertToYmd($item['end_date']);
+            }
+
+            if (isset($item['start_date'])) {
+                $item['start_date'] = convertToYmd($item['start_date']);
+            }
+
+            return $item;
+        }, $data);
+    }
 }

--- a/database/migrations/install/2025_12_10_000014_create_legal_entities_table.php
+++ b/database/migrations/install/2025_12_10_000014_create_legal_entities_table.php
@@ -45,7 +45,6 @@ return new class extends Migration
             $table->enum('license_sync_status', JobStatus::values())->nullable();
             $table->enum('document_sync_status', JobStatus::values())->nullable();
             $table->enum('declaration_sync_status', JobStatus::values())->nullable();
-            $table->enum('declaration_request_sync_status', JobStatus::values())->nullable();
             $table->enum('equipment_sync_status', JobStatus::values())->nullable();
             $table->timestamp('inserted_at')->nullable();
             $table->date('ehealth_inserted_at')->nullable();

--- a/database/migrations/update/0_1/2026_02_04_154212_remove_declaration_request_sync_status_to_legal_entity.php
+++ b/database/migrations/update/0_1/2026_02_04_154212_remove_declaration_request_sync_status_to_legal_entity.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Enums\JobStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('legal_entities', function (Blueprint $table) {
+            if (Schema::hasColumn('legal_entities', 'declaration_request_sync_status')) {
+                $table->dropColumn('declaration_request_sync_status');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('legal_entities', function (Blueprint $table) {
+            if (! Schema::hasColumn('legal_entities', 'declaration_request_sync_status')) {
+                $table->enum('declaration_request_sync_status', JobStatus::values())->nullable();
+            }
+        });
+    }
+};

--- a/resources/views/livewire/declaration/declaration-index.blade.php
+++ b/resources/views/livewire/declaration/declaration-index.blade.php
@@ -1,4 +1,5 @@
 @use('App\Enums\Declaration\Status')
+@use('App\Enums\JobStatus')
 @use('Carbon\CarbonImmutable')
 @use('\App\Enums\User\Role')
 
@@ -15,7 +16,7 @@
                 {{ $this->isSync ? 'disabled' : '' }}
             >
                 @icon('refresh', 'w-4 h-4')
-                <span>{{ __('forms.synchronise_with_eHealth') }}</span>
+                <span>{{ ($syncStatus === JobStatus::PAUSED->value || $syncStatus === JobStatus::FAILED->value) ? __('forms.sync_retry') : __('forms.synchronise_with_eHealth') }}</span>
             </button>
         </div>
 

--- a/resources/views/livewire/division/division-index.blade.php
+++ b/resources/views/livewire/division/division-index.blade.php
@@ -1,4 +1,5 @@
 @use('App\Enums\Status')
+@use('App\Enums\JobStatus')
 @use('App\Models\{HealthcareService, Division}')
 
 <div x-data="{
@@ -30,7 +31,7 @@
                 {{ $this->isSync ? 'disabled' : '' }}
             >
                 @icon('refresh', 'w-4 h-4')
-                <span>{{ __('forms.synchronise_with_eHealth') }}</span>
+                <span>{{ ($syncStatus === JobStatus::PAUSED->value || $syncStatus === JobStatus::FAILED->value) ? __('forms.sync_retry') : __('forms.synchronise_with_eHealth') }}</span>
             </button>
         </div>
     </x-header-navigation>

--- a/resources/views/livewire/division/healthcare-service/healthcare-service-index.blade.php
+++ b/resources/views/livewire/division/healthcare-service/healthcare-service-index.blade.php
@@ -1,4 +1,5 @@
 @use('App\Enums\Status')
+@use('App\Enums\JobStatus')
 @use('App\Models\HealthcareService')
 
 <div
@@ -46,7 +47,7 @@
                                 {{ $this->isSync ? 'disabled' : '' }}
                             >
                                 @icon('refresh', 'w-4 h-4')
-                                {{ __('forms.synchronise_with_eHealth') }}
+                                <span>{{ ($syncStatus === JobStatus::PAUSED->value || $syncStatus === JobStatus::FAILED->value) ? __('forms.sync_retry') : __('forms.synchronise_with_eHealth') }}</span>
                             </button>
                         @endcan
                     </div>

--- a/resources/views/livewire/employee-request/employee-request-index.blade.php
+++ b/resources/views/livewire/employee-request/employee-request-index.blade.php
@@ -1,3 +1,5 @@
+@use('App\Enums\JobStatus')
+
 <div>
     {{-- 1. DEFINE PERMISSIONS --}}
     @php
@@ -26,7 +28,7 @@
             >
                 <span wire:loading.remove wire:target="sync">@icon('refresh', 'w-4 h-4')</span>
                 <span wire:loading wire:target="sync" class="animate-spin">@icon('refresh', 'w-4 h-4')</span>
-                <span>{{ __('forms.sync_all') }}</span>
+                <span>{{ ($syncStatus === JobStatus::PAUSED->value || $syncStatus === JobStatus::FAILED->value) ? __('forms.sync_retry') : __('forms.sync_all') }}</span>
             </button>
         </div>
 

--- a/resources/views/livewire/employee-role/employee-role-index.blade.php
+++ b/resources/views/livewire/employee-role/employee-role-index.blade.php
@@ -1,4 +1,5 @@
 @use('App\Enums\Status')
+@use('App\Enums\JobStatus')
 @use('App\Models\EmployeeRole')
 
 <div>
@@ -25,7 +26,7 @@
                 {{ $this->isSync ? 'disabled' : '' }}
             >
                 @icon('refresh', 'w-4 h-4')
-                {{ __('forms.synchronise_with_eHealth') }}
+                <span>{{ ($syncStatus === JobStatus::PAUSED->value || $syncStatus === JobStatus::FAILED->value) ? __('forms.sync_retry') : __('forms.synchronise_with_eHealth') }}</span>
             </button>
         </div>
 

--- a/resources/views/livewire/employee/employee-index.blade.php
+++ b/resources/views/livewire/employee/employee-index.blade.php
@@ -1,3 +1,5 @@
+@use('App\Enums\JobStatus')
+
 <div>
     @php
         use App\Enums\User\Role;
@@ -34,7 +36,7 @@
                     {{ $this->isSync ? 'disabled' : '' }}
                 >
                     @icon('refresh', 'w-4 h-4')
-                    {{ __('forms.synchronise_with_eHealth') }}
+                    <span>{{ ($syncStatus === JobStatus::PAUSED->value || $syncStatus === JobStatus::FAILED->value) ? __('forms.sync_retry') : __('forms.synchronise_with_eHealth') }}</span>
                 </button>
             </div>
         @endcan

--- a/resources/views/livewire/equipment/equipment-index.blade.php
+++ b/resources/views/livewire/equipment/equipment-index.blade.php
@@ -1,6 +1,7 @@
 @php
     use App\Enums\Equipment\{Status, AvailabilityStatus};
     use App\Models\Equipment;
+    use App\Enums\JobStatus;
 @endphp
 
 <div>
@@ -26,7 +27,7 @@
                     {{ $this->isSync ? 'disabled' : '' }}
                 >
                     @icon('refresh', 'w-4 h-4')
-                    {{ __('forms.synchronise_with_eHealth') }}
+                    <span>{{ ($syncStatus === JobStatus::PAUSED->value || $syncStatus === JobStatus::FAILED->value) ? __('forms.sync_retry') : __('forms.synchronise_with_eHealth') }}</span>
                 </button>
             @endcan
         </div>

--- a/resources/views/livewire/legal-entity/legal-entity-details.blade.php
+++ b/resources/views/livewire/legal-entity/legal-entity-details.blade.php
@@ -1,5 +1,6 @@
 @php
     use App\Models\LegalEntity;
+    use App\Enums\JobStatus;
 
     $le = $this->legalEntity;
     $isEdit = $isDetails = true;
@@ -42,7 +43,7 @@
                         {{ $this->isSync ? 'disabled' : '' }}
                     >
                         @icon('refresh', 'w-4 h-4')
-                        {{ __('forms.synchronise_with_eHealth') }}
+                        <span>{{ ($syncStatus === JobStatus::PAUSED->value || $syncStatus === JobStatus::FAILED->value) ? __('forms.sync_retry') : __('forms.synchronise_with_eHealth') }}</span>
                     </button>
                 </div>
             @endcan


### PR DESCRIPTION
This PR concerns the #663 ISSUE

Що було зроблено:
- додана можливість відновлення призупиненої синхронізації для EmployeeRequest:
- додана можливість відновлення призупиненої синхронізації для Division;
- додана можливість відновлення призупиненої синхронізації для HealthCare Service;
- додана можливість відновлення призупиненої синхронізації для Employee;
- додана можливість відновлення призупиненої синхронізації для EmployeeRole;
- додана можливість відновлення призупиненої синхронізації для Declaration;
- додана можливість відновлення призупиненої синхронізації для Equipment;
- додана можливість відновлення призупиненої синхронізації для закладу на етапі першого входу (без релогіну);
- додано зміну тексту на кнопках синхронізації залежно від поточної ситуації.