### PR TITLE
#536: fix bug for empty or missed data for some cases

### DIFF
--- a/app/Livewire/LegalEntity/LegalEntity.php
+++ b/app/Livewire/LegalEntity/LegalEntity.php
@@ -568,6 +568,10 @@ abstract class LegalEntity extends Component
         foreach ($dataItems as $item) {
             $itemValue = Arr::get($data, $item);
 
+            if (empty($itemValue)) {
+                continue;
+            }
+
             if (\is_array($itemValue)) {
                 $reformatted = collect($itemValue)->map(function($item) {
                     if (isset($item['date'])) {


### PR DESCRIPTION
This PR concers the #536 ISSUE

Що було зроблено: 
- пофікшнено баг, коли не вказуються дати видачі документа та дати закінчення ліцензії