### PR TITLE
#610: fix update migration to remove unique index from equipments table

### DIFF
--- a/database/migrations/update/0_1/2026_01_27_171017_remove_unique_index_from_equipments_table.php
+++ b/database/migrations/update/0_1/2026_01_27_171017_remove_unique_index_from_equipments_table.php
@@ -2,19 +2,25 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration
 {
+    protected const string TABLE_NAME = 'equipments';
+    protected const string INDEX_NAME = 'equipments_legal_entity_id_inventory_number_unique';
+
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::table('equipments', static function (Blueprint $table) {
-            $table->dropUnique(['legal_entity_id', 'inventory_number']);
+        Schema::table(self::TABLE_NAME, static function (Blueprint $table) {
+            if (self::isUniqueIndexExists(self::TABLE_NAME, self::INDEX_NAME)) {
+                $table->dropUnique(self::INDEX_NAME);
+            }
         });
     }
 
@@ -23,8 +29,26 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('equipments', static function (Blueprint $table) {
-            $table->unique(['legal_entity_id', 'inventory_number']);
+        Schema::table(self::TABLE_NAME, static function (Blueprint $table) {
+            if (! self::isUniqueIndexExists(self::TABLE_NAME, self::INDEX_NAME)) {
+                $table->unique(
+                    ['legal_entity_id', 'inventory_number'],
+                    self::INDEX_NAME
+                );
+            }
         });
+    }
+
+    protected static function isUniqueIndexExists(string $table, string $index): bool
+    {
+        $indexes = Schema::getIndexes($table);
+
+        foreach ($indexes as $idx) {
+            if ($idx['name'] === $index && $idx['unique'] === true) {
+                return true;
+            }
+        }
+
+        return false;
     }
 };


### PR DESCRIPTION
This PR concerns the #610 ISSUE

Що було зроблено:
- пофікшено баг, який призводив до помилки під час виклику `php artisan update` для міграції, яка видаляла унікальні індекси в таблиці `equipments`. Баг проявлявся у випадку, якщо індекси не були сформовані.