### PR TITLE
#536: fix issues for MySQL database when new LegalEntity being created

### DIFF
--- a/app/Livewire/LegalEntity/LegalEntity.php
+++ b/app/Livewire/LegalEntity/LegalEntity.php
@@ -887,6 +887,9 @@ abstract class LegalEntity extends Component
      */
     protected function saveLicense(array $data): void
     {
+        $data['ehealth_inserted_at'] = convertToYmd($data['ehealth_inserted_at']);
+        $data['ehealth_updated_at'] = convertToYmd($data['ehealth_updated_at']);
+
         $license = License::firstOrNew(['uuid' => $data['uuid']]);
         $license->fill($data);
         $license->is_primary = true;


### PR DESCRIPTION
This PR concerns the #536 ISSUE

Що було зроблено:
- пофікешено баг, який у випадку використання бази даних MySQL видавав помилку при спробі зберегти дані ліцензії, які повернув ЕСОЗ при успішному створенні Закладу.