### PR TITLE
#536: ESOZ TESTING: fix beneficiary behavior

### DIFF
--- a/app/Livewire/LegalEntity/EditLegalEntity.php
+++ b/app/Livewire/LegalEntity/EditLegalEntity.php
@@ -7,7 +7,6 @@ namespace App\Livewire\LegalEntity;
 use Log;
 use Exception;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
 use App\Models\Employee\Employee;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
@@ -58,6 +57,8 @@ class EditLegalEntity extends LegalEntity
         $this->getArchiveForm(); // Get the archive form data
         $this->getOwnerLegalEntity(); // Get the owner's legal entity data
         $this->getAccreditationForm(); // Get the accreditation form data status
+        $this->getBeneficiaryForm(); // Get the beneficiary form data status
+        $this->getReceiverFundsCodeForm(); // Get the receiver funds code form data status
     }
 
     /**
@@ -90,9 +91,8 @@ class EditLegalEntity extends LegalEntity
      */
     protected function getArchiveForm(): void
     {
-        // Extracting only 'date' and 'place' fields from the first element of the archive
+         // if the legal entity has an archive, the 'archivationShow' property is set to true
         if (!empty($this->legalEntityForm->archive)) {
-            // if the legal entity has an archive, the 'archivationShow' property is set to true
             $this->legalEntityForm->archivationShow = true;
         }
     }
@@ -107,6 +107,26 @@ class EditLegalEntity extends LegalEntity
     {
         if (!empty($this->legalEntityForm->accreditation) && $this->legalEntityForm->accreditation['category'] !== null) {
             $this->legalEntityForm->accreditationShow = true;
+        }
+    }
+
+    /**
+     * If the legal entity has an beneficiary, the 'beneficiaryShow' property is set to true
+     */
+    protected function getBeneficiaryForm(): void
+    {
+        if (!empty($this->legalEntityForm->beneficiary)) {
+            $this->legalEntityForm->beneficiaryShow = true;
+        }
+    }
+
+    /**
+     * If the legal entity has an beneficiary, the 'receiverFundsCodeShow' property is set to true
+     */
+    protected function getReceiverFundsCodeForm(): void
+    {
+        if (!empty($this->legalEntityForm->receiverFundsCode)) {
+            $this->legalEntityForm->receiverFundsCodeShow = true;
         }
     }
 

--- a/app/Livewire/LegalEntity/Forms/LegalEntitiesForms.php
+++ b/app/Livewire/LegalEntity/Forms/LegalEntitiesForms.php
@@ -40,6 +40,10 @@ class LegalEntitiesForms extends Form
 
     public ?array $residenceAddress = [];
 
+    public bool $beneficiaryShow = false;
+
+    public bool $receiverFundsCodeShow = false;
+
     public bool $archivationShow = false;
 
     public bool $accreditationShow = false;
@@ -115,12 +119,12 @@ class LegalEntitiesForms extends Form
             'license.orderNo' => 'required|string',
             'license.licenseNumber' => ['nullable', 'string', 'regex:/^(?!.*[ЫЪЭЁыъэё@$^#])[a-zA-ZА-ЯҐЇІЄа-яґїіє0-9№\"!\^\*)\]\[(&._-].*$/'],
             'receiverFundsCode' => [
-                legalEntity()?->receiverFundsCode ? 'required' : 'nullable',
+                'nullable',
                 'string',
                 'regex:/^[0-9]+$/'
             ],
             'beneficiary' => [
-                legalEntity()?->beneficiary ? 'required' : 'nullable',
+                'nullable',
                 'string',
                 new Cyrillic(),
                 "regex:/^(?!.*[ЫЪЭЁыъэё@%&$^#])[А-ЯҐЇІЄа-яґїіє’\'\- ]+$/u",
@@ -360,5 +364,29 @@ class LegalEntitiesForms extends Form
             new PhoneDuplicates($this->phones),
             new PhoneDuplicates($this->owner['phones'])
         ];
+    }
+
+    /**
+     * Handles updates to the beneficiary value.
+     *
+     * @param string $value The updated beneficiary value.
+     *
+     * @return void
+     */
+    public function onBeneficiaryUpdated(string $value): void
+    {
+        $this->beneficiaryShow = !empty($value);
+    }
+
+    /**
+     * Handle updates to the receiver funds code value.
+     *
+     * @param string $value The updated receiver funds code.
+     *
+     * @return void
+     */
+    public function onReceiverFundsCodeUpdated(string $value): void
+    {
+        $this->receiverFundsCodeShow = !empty($value);
     }
 }

--- a/app/Livewire/LegalEntity/LegalEntity.php
+++ b/app/Livewire/LegalEntity/LegalEntity.php
@@ -227,6 +227,30 @@ abstract class LegalEntity extends Component
     }
 
     /**
+     * Livewire lifecycle hook triggered when the beneficiary field is updated.
+     *
+     * @param  mixed  $value  The new value of the beneficiary field
+     *
+     * @return void
+     */
+    public function updatedLegalEntityFormBeneficiary($value)
+    {
+        $this->legalEntityForm->onBeneficiaryUpdated($value);
+    }
+
+    /**
+     * Livewire lifecycle hook triggered when the receiverFundsCode field is updated.
+     *
+     * @param  mixed  $value  The new value of the receiverFundsCode field
+     *
+     * @return void
+     */
+    public function updatedLegalEntityFormReceiverFundsCode($value)
+    {
+        $this->legalEntityForm->onReceiverFundsCodeUpdated($value);
+    }
+
+    /**
      * Step 8 for handling sign legal entity  submission.
      *
      * @throws ValidationException
@@ -545,7 +569,13 @@ abstract class LegalEntity extends Component
         // Converting archive to array
         $data['archive'] = $data['archivation_show'] ? $data['archive'] : [];
 
-        Arr::forget($data, ['archivation_show', 'accreditation_show']);
+        Arr::forget($data, [
+            'archivation_show',
+            'accreditation_show',
+            'beneficiary_show',
+            'receiver_funds_code_show'
+            ]
+        );
 
         $data = removeEmptyKeys($data);
 
@@ -813,6 +843,16 @@ abstract class LegalEntity extends Component
 
             if (empty($data['data']['archive'])) {
                 $this->legalEntity->archive = null;
+            }
+
+            if (empty($data['data']['beneficiary']) || !$this->legalEntityForm->beneficiaryShow) {
+                $this->legalEntity->beneficiary = null;
+                unset($data['data']['beneficiary']);
+            }
+
+            if (empty($data['data']['receiver_funds_code']) || !$this->legalEntityForm->receiverFundsCodeShow) {
+                $this->legalEntity->receiverFundsCode = null;
+                unset($data['data']['receiver_funds_code']);
             }
 
             // Fill the object with data

--- a/app/Livewire/LegalEntity/LegalEntityDetails.php
+++ b/app/Livewire/LegalEntity/LegalEntityDetails.php
@@ -109,6 +109,8 @@ class LegalEntityDetails extends LegalEntityComponent
         $this->getArchiveForm(); // Get the archive form data
         $this->getOwnerLegalEntity(); // Get the owner's legal entity data
         $this->getAccreditationForm(); // Get the accreditation form data status
+        $this->getBeneficiaryForm(); // Get the beneficiary form data status
+        $this->getReceiverFundsCodeForm(); // Get the receiver funds code form data status
 
         $this->legalEntityForm->residenceAddress = $this->address;
     }
@@ -159,6 +161,26 @@ class LegalEntityDetails extends LegalEntityComponent
     {
         if (!empty($this->legalEntityForm->accreditation) && $this->legalEntityForm->accreditation['category'] !== null) {
             $this->legalEntityForm->accreditationShow = true;
+        }
+    }
+
+    /**
+     * If the legal entity has an beneficiary, the 'beneficiaryShow' property is set to true
+     */
+    protected function getBeneficiaryForm(): void
+    {
+        if (!empty($this->legalEntityForm->beneficiary)) {
+            $this->legalEntityForm->beneficiaryShow = true;
+        }
+    }
+
+    /**
+     * If the legal entity has an beneficiary, the 'receiverFundsCodeShow' property is set to true
+     */
+    protected function getReceiverFundsCodeForm(): void
+    {
+        if (!empty($this->legalEntityForm->receiverFundsCode)) {
+            $this->legalEntityForm->receiverFundsCodeShow = true;
         }
     }
 


### PR DESCRIPTION
This PR concerns the #536 ISSUE

Що було зроблено:

- поля "Бенефіціар" і "Код розпорядника" тепер синхронізуються з поточним станом, не залежно від стану, який повертає ЕСОЗ (проблема полягає в тому, що ці поля - не обов'язкові), але якщо поле було хоч раз ініційовано - ЕСОЗ повертає вже збережене значення, навіть якщо йому передати пусте значення поля);
- для полів "Бенефіціар" і "Код розпорядника"  прибрано статус обов'язкових при редагуванні закладу.