### PR TITLE
#470: fix division creation error

### DIFF
--- a/app/Livewire/Division/Forms/DivisionForm.php
+++ b/app/Livewire/Division/Forms/DivisionForm.php
@@ -54,8 +54,8 @@ class DivisionForm extends Form
             'sun' => [[Division::WORKING_TIME_DEFAULT_START, Division::WORKING_TIME_DEFAULT_END]]
         ],
         'location' => [
-            Division::WORKING_TIME_DEFAULT_START,
-            Division::WORKING_TIME_DEFAULT_END
+            'latitude' => Division::LOCATION_DEFAULT_LATITUDE,
+            'longitude' => Division::LOCATION_DEFAULT_LONGITUDE
         ],
         'phones' => []
     ];


### PR DESCRIPTION
Що було зроблено:

- пофікшено початкові значення для параметра `location`, що призводили до помилки, у випадку коли координати не були вказані.