### PR TITLE
#596: update permissions after scopes being updated

### DIFF
--- a/app/Console/Commands/MigrationsCommand.php
+++ b/app/Console/Commands/MigrationsCommand.php
@@ -41,6 +41,12 @@ abstract class MigrationsCommand extends Command
      */
     public function handle(Migrator $migrator): void
     {
+        if ($this->option('scopes')) {
+            $this->updateScopes();
+
+            return;
+        }
+
         $this->cacheClear();
 
         $this->beforeMigrations();
@@ -168,5 +174,16 @@ abstract class MigrationsCommand extends Command
         foreach ($pendingFiles as $file) {
             $this->line("<comment>   Proceeded: </comment>{$file}");
         }
+    }
+
+    /**
+     * Update permissions dependencies for all concerns tables if scopes has been updated in the config file
+     *
+     * @return void
+     */
+    protected function updateScopes(): void
+    {
+        $this->info('Updating scopes...');
+
     }
 }

--- a/app/Console/Commands/Update.php
+++ b/app/Console/Commands/Update.php
@@ -15,7 +15,12 @@ class Update extends MigrationsCommand
      *
      * @var string
      */
-    protected $signature = 'update {--clear : Clear the cache before installation} {--rollback : Rollback the last batch of migrations} {--step=0 : The number of migration batches to rollback} {--ver= : Specify the target version to update to}';
+    protected $signature = 'update 
+        {--clear : Clear the cache before installation} 
+        {--rollback : Rollback the last batch of migrations} 
+        {--step=0 : The number of migration batches to rollback} 
+        {--ver= : Specify the target version to update to} 
+        {--scopes : Update the scopes (depends on config)} ';
 
     /**
      * The console command description.


### PR DESCRIPTION
Після оновлення скоупів в конфіг-файлі потрібно синхронізувати скоупи в БД відносно даних з конфігу.

Що було зроблено:

- додано ключ "--scopes" do консольної команди `update`